### PR TITLE
Exit ParseHIDData Early if no controller found

### DIFF
--- a/RFUSB_to_DB15/RFUSB_to_DB15.ino
+++ b/RFUSB_to_DB15/RFUSB_to_DB15.ino
@@ -120,6 +120,8 @@ class JoystickHID : public HIDUniversal {
         cnv_pointer++;
       }
 
+      if (Tbl_cnv_data[cnv_pointer].joy_type == -1) return;
+
       /*   Serial.print(VID, HEX);
           Serial.print(F(":"));
           Serial.print(PID, HEX);


### PR DESCRIPTION
Simple fix to exit early when we don't know what controller we have. This will prevent undefined behavior.