### PR TITLE
Add Support for Xbox and PS3 Profiles

### DIFF
--- a/RFUSB_to_DB15/Controller.h
+++ b/RFUSB_to_DB15/Controller.h
@@ -1,0 +1,17 @@
+//
+// Created by Kitsune on 8/21/2020.
+//
+
+#ifndef USB2DB15_CONTROLLER_H
+#define USB2DB15_CONTROLLER_H
+
+#include <stdint.h>
+
+class Controller {
+public:
+  virtual bool GetButtonState(uint8_t button);
+  virtual bool Connected();
+};
+
+
+#endif //USB2DB15_CONTROLLER_H

--- a/RFUSB_to_DB15/PS3Controller.cpp
+++ b/RFUSB_to_DB15/PS3Controller.cpp
@@ -1,0 +1,52 @@
+//
+// Created by Kitsune on 8/21/2020.
+//
+
+#include "PS3Controller.h"
+#include "device_descriptor.h"
+
+PS3Controller::PS3Controller(PS3USB *p) {
+  ps3usb = p;
+}
+
+bool PS3Controller::GetButtonState(uint8_t button) {
+  switch(button) {
+    case BUTTON_UP:
+      return ps3usb->getButtonPress(UP);
+    case BUTTON_DOWN:
+      return ps3usb->getButtonPress(DOWN);
+    case BUTTON_LEFT:
+      return ps3usb->getButtonPress(LEFT);
+    case BUTTON_RIGHT:
+      return ps3usb->getButtonPress(RIGHT);
+    case BUTTON_START:
+      return ps3usb->getButtonPress(START);
+    case BUTTON_COIN:
+      return ps3usb->getButtonPress(BACK);
+    case BUTTON_1:
+      return ps3usb->getButtonPress(SQUARE);
+    case BUTTON_2:
+      return ps3usb->getButtonPress(TRIANGLE);
+    case BUTTON_3:
+      return ps3usb->getButtonPress(R1);
+    case BUTTON_4:
+      return ps3usb->getButtonPress(X);
+    case BUTTON_5:
+      return ps3usb->getButtonPress(CIRCLE);
+    case BUTTON_6:
+      return ps3usb->getButtonPress(R2);
+    case BUTTON_7:
+      return ps3usb->getButtonPress(L1);
+    case BUTTON_8:
+      return ps3usb->getButtonPress(L2);
+    case BUTTON_9:
+      return ps3usb->getButtonPress(R3);
+    case BUTTON_10:
+      return ps3usb->getButtonPress(L3);
+  }
+  return false;
+}
+
+bool PS3Controller::Connected() {
+  return ps3usb->PS3Connected;
+}

--- a/RFUSB_to_DB15/PS3Controller.h
+++ b/RFUSB_to_DB15/PS3Controller.h
@@ -1,0 +1,21 @@
+//
+// Created by Kitsune on 8/21/2020.
+//
+
+#ifndef USB2DB15_PS3CONTROLLER_H
+#define USB2DB15_PS3CONTROLLER_H
+
+#include <PS3USB.h>
+#include "Controller.h"
+
+class PS3Controller : public Controller {
+  PS3USB *ps3usb;
+public:
+  PS3Controller(PS3USB *p);
+
+  bool GetButtonState(uint8_t button);
+  bool Connected();
+};
+
+
+#endif //USB2DB15_PS3CONTROLLER_H

--- a/RFUSB_to_DB15/Profile.cpp
+++ b/RFUSB_to_DB15/Profile.cpp
@@ -1,0 +1,31 @@
+//
+// Created by Kitsune on 8/21/2020.
+//
+
+#include "Profile.h"
+
+uint8_t Profile::SwapButtons(uint8_t a, uint8_t b) {
+  if(a >= NUM_BUTTON_BINDINGS || b >= NUM_BUTTON_BINDINGS) {
+    return 1;
+  }
+
+  uint8_t temp = bindings[a];
+  bindings[a] = bindings[b];
+  bindings[b] = temp;
+  return 0;
+}
+
+uint8_t Profile::SetButton(uint8_t target, uint8_t destination) {
+  if(destination >= NUM_BUTTON_BINDINGS) {
+    return 1;
+  }
+
+  bindings[destination] = target;
+  return 0;
+}
+
+void Profile::Copy(Profile &p) {
+  for(uint8_t i = 0; i < NUM_BUTTON_BINDINGS; i++) {
+    bindings[i] = p.bindings[i];
+  }
+}

--- a/RFUSB_to_DB15/Profile.h
+++ b/RFUSB_to_DB15/Profile.h
@@ -1,0 +1,35 @@
+//
+// Created by Kitsune on 8/21/2020.
+//
+
+#ifndef USB2DB15_PROFILE_H
+#define USB2DB15_PROFILE_H
+
+#include <stdint.h>
+
+#define NUM_BUTTON_BINDINGS 12
+
+// Profile Buttons
+#define PROFILE_BUTTON_UP       0
+#define PROFILE_BUTTON_RIGHT    1
+#define PROFILE_BUTTON_DOWN     2
+#define PROFILE_BUTTON_LEFT     3
+#define PROFILE_BUTTON_START    4
+#define PROFILE_BUTTON_COIN     5
+#define PROFILE_BUTTON_1        6
+#define PROFILE_BUTTON_2        7
+#define PROFILE_BUTTON_3        8
+#define PROFILE_BUTTON_4        9
+#define PROFILE_BUTTON_5        10
+#define PROFILE_BUTTON_6        11
+
+struct Profile {
+  uint8_t bindings[NUM_BUTTON_BINDINGS];
+
+  uint8_t SwapButtons(uint8_t a, uint8_t b);
+  uint8_t SetButton(uint8_t target, uint8_t destination);
+  void Copy(Profile &p);
+};
+
+
+#endif //USB2DB15_PROFILE_H

--- a/RFUSB_to_DB15/RFUSB_to_DB15.ino
+++ b/RFUSB_to_DB15/RFUSB_to_DB15.ino
@@ -46,6 +46,10 @@
 #include <hiduniversal.h>
 #include <usbhub.h>
 
+#include "PS3Controller.h"
+#include "XBoxOneController.h"
+#include "USB2DB15.h"
+
 #define TYPE_PS4 0
 #define TYPE_MDmini 1
 #define TYPE_PSC 2
@@ -210,6 +214,11 @@ class JoystickHID : public HIDUniversal {
           if (buf[0] & 0x0020) { // R1ボタン
             output |= 1;
             Serial.println("C button");
+          }
+
+          if (buf[0] & 0x0040) { // Z Retrobit
+            output |= 1;
+            Serial.println("C button_RETROBIT");
           }
 
           if (buf[0] & 0x0080) { // R2ボタン
@@ -476,6 +485,10 @@ USB Usb;
 PS3USB PS3(&Usb);
 XBOXONE Xbox(&Usb);
 //XBOXUSB XboxT(&Usb);
+PS3Controller PS3Con(&PS3);
+XBoxOneController XBoxCon(&Xbox);
+USB2DB15 Usb2db15(PS3Con, XBoxCon);
+
 
 USBHub Hub(&Usb);
 JoystickHID Hid1(&Usb);
@@ -484,8 +497,6 @@ JoystickHID Hid1(&Usb);
 //JoystickHID Hid4(&Usb);
 
 void setup() {
-//  pinMode(LED_PIN, OUTPUT);
-//  digitalWrite(LED_PIN, HIGH); // LED starts off
 
   byte i, j;
 
@@ -503,189 +514,12 @@ void setup() {
 void loop() {
 
   Usb.Task();
-//
-//  if ( (Usb.getUsbTaskState() == USB_STATE_RUNNING) && !led_on ) {
-//    digitalWrite(LED_PIN, LOW); // LED is on when low
-//    Serial.println(F("LED On"));
-//    led_on = true;
-//  }
-//  else if ( (Usb.getUsbTaskState() == USB_DETACHED_SUBSTATE_WAIT_FOR_DEVICE) && led_on ) {
-//    digitalWrite(LED_PIN, HIGH); // LED is off when high
-//    Serial.println(F("LED Off"));
-//    led_on = false;
-//  }
-
-  if (PS3.PS3Connected) {
-
-    output = 0;
-
-    if (PS3.getButtonPress(UP)) {
-      output |= 8; // pin A3
-      Serial.println(F("Up"));
-    }
-
-    if (PS3.getButtonPress(LEFT)) {
-      output |= 4; //pin A2
-      Serial.println(F("Left"));
-    }
-
-    if (PS3.getButtonPress(SQUARE)) {
-      output |= 2; //A1
-      Serial.println(F("Square"));
-    }
-
-    if (PS3.getButtonPress(START)) {
-      output |= 32;
-      Serial.println(F("Start"));
-    }
-
-    if (PS3.getButtonPress(R1)) {
-      output |= 1;
-      Serial.println(F("R1"));
-    }
-
-    if (PS3.getButtonPress(R2)) {
-      output |= 16;
-      Serial.println(F("R2"));
-    }
-
-    DDRC = output;
-    output = 0;
-
-    if (PS3.getButtonPress(DOWN)) {
-      output |= 4; // pin 2
-      Serial.println(F("Down"));
-    }
-
-    if (PS3.getButtonPress(TRIANGLE)) {
-      output |= 16;
-      Serial.println(F("\r\nTriangle"));
-    }
-
-    if (PS3.getButtonPress(CIRCLE)) {
-      output |= 128;
-      Serial.println(F("Circle"));
-    }
-
-    if (PS3.getButtonPress(X)) {
-      output |= 32; //pin 5
-      Serial.println(F("X"));
-    }
-    if (PS3.getButtonPress(RIGHT)) {
-      output |= 8; //pin 3
-
-      Serial.println(F("Right"));
-    }
-
-    if (PS3.getButtonPress(SELECT)) {
-      output |= 64; //pin 6
-      Serial.println(F("Select"));
-    }
-
-    DDRD = output;
-  }
 
   delay(1);
 
-
-  if (Xbox.XboxOneConnected)
-
-  {
-    if (Xbox.getAnalogHat(LeftHatX) > 7500 || Xbox.getAnalogHat(LeftHatX) < -7500
-        || Xbox.getAnalogHat(LeftHatY) > 7500 || Xbox.getAnalogHat(LeftHatY) < -7500 )
-    {
-      if (Xbox.getAnalogHat(LeftHatX) > 7500
-          || Xbox.getAnalogHat(LeftHatX) < -7500) {
-        Serial.print(F("LeftHatX: "));
-        Serial.print(Xbox.getAnalogHat(LeftHatX));
-        Serial.print("\t");
-      }
-      if (Xbox.getAnalogHat(LeftHatY) > 7500
-          || Xbox.getAnalogHat(LeftHatY) < -7500) {
-        Serial.print(F("LeftHatY: "));
-        Serial.print(Xbox.getAnalogHat(LeftHatY));
-        Serial.print("\t");
-      }
-
-      Serial.println();
-    }
-
-    Xbox.setRumbleOff();
-
-    output = 0;
-
-
-    if (Xbox.getButtonPress(UP))  {
-      output |= 8; // pin A3
-      Serial.println(F("Up"));
-    }
-
-
-    if (Xbox.getButtonPress(LEFT)) {
-      output |= 4; //pin A2
-      Serial.println(F("Left"));
-    }
-
-    if (Xbox.getButtonPress(X))  {
-      output |= 2; //A1
-      Serial.println(F("X"));
-    }
-
-    if (Xbox.getButtonPress(START))  {
-      output |= 32;
-      Serial.println(F("Start"));
-    }
-
-    if (Xbox.getButtonPress(R1))  {
-      output |= 1;
-      Serial.println(F("R1"));
-    }
-
-    if (Xbox.getButtonPress(R2))  {
-      output |= 16;
-      Serial.println(F("R2"));
-    }
-
-    DDRC = output;
-    output = 0;
-
-    if (Xbox.getButtonPress(DOWN))  {
-      output |= 4; // pin 2
-      Serial.println(F("Down"));
-    }
-
-
-    if (Xbox.getButtonPress(Y))  {
-      output |= 16;
-      Serial.println(F("Y"));
-    }
-
-    if (Xbox.getButtonPress(A)) {
-      output |= 32;
-      Serial.println(F("A"));
-    }
-
-    if (Xbox.getButtonPress(B))  {
-      output |= 128; //pin 7
-      Serial.println(F("B"));
-    }
-    if (Xbox.getButtonPress(RIGHT))  {
-      output |= 8; //pin 3
-
-      Serial.println(F("Right"));
-    }
-
-    if (Xbox.getButtonPress(BACK))  {
-      output |= 64; //pin 6
-      Serial.println(F("Back"));
-    }
-
-    DDRD = output;
-  }
-
+  Usb2db15.GenerateOutput();
 
   delay(1);
-
 
 }
 

--- a/RFUSB_to_DB15/USB2DB15.cpp
+++ b/RFUSB_to_DB15/USB2DB15.cpp
@@ -1,0 +1,221 @@
+//
+// Created by Kitsune on 8/21/2020.
+//
+
+#include "USB2DB15.h"
+
+void debugOutput(uint8_t ddrc, uint8_t ddrd) {
+  Serial.print("Output: ");
+  if( ddrc & DDRC_UP) {
+    Serial.print("UP ");
+  }
+
+  if( ddrd & DDRD_DOWN) {
+    Serial.print("DOWN ");
+  }
+
+  if( ddrc & DDRC_LEFT) {
+    Serial.print("LEFT ");
+  }
+
+  if( ddrd & DDRD_RIGHT) {
+    Serial.print("RIGHT ");
+  }
+
+  if( ddrc & DDRC_START) {
+    Serial.print("START ");
+  }
+
+  if( ddrd & DDRD_COIN) {
+    Serial.print("SELECT ");
+  }
+
+  if( ddrc & DDRC_1) {
+    Serial.print("A ");
+  }
+
+  if( ddrd & DDRD_2) {
+    Serial.print("B ");
+  }
+
+  if( ddrc & DDRC_3) {
+    Serial.print("C ");
+  }
+
+  if( ddrd & DDRD_4) {
+    Serial.print("X ");
+  }
+
+  if( ddrd & DDRD_5) {
+    Serial.print("Y ");
+  }
+
+  if( ddrc & DDRC_6) {
+    Serial.print("Z ");
+  }
+  Serial.println(" ");
+}
+
+USB2DB15::USB2DB15(PS3Controller &ps3, XBoxOneController &xbox) : ps3(ps3), xbox(xbox) {
+  GenerateBuiltinProfiles();
+};
+
+void USB2DB15::GenerateOutput() {
+  uint8_t ddrc = 0; // getDDRC();
+  uint8_t ddrd = 0; // getDDRD();
+  uint8_t button = 0;
+
+  // Select the Controller and Generate DDRC and DDRD
+  if(ps3.Connected()) { // PS3
+    ddrc = GetDDRC(profiles[curProfile], ps3);
+    ddrd = GetDDRD(profiles[curProfile], ps3);
+  } else if (xbox.Connected()) { // XboxOne
+    ddrc = GetDDRC(profiles[curProfile], xbox);
+    ddrd = GetDDRD(profiles[curProfile], xbox);
+  }
+
+  if(ddrc == prevDDRC && ddrd == prevDDRD) {
+    return; // Nothing has changed
+  }
+  prevDDRC = ddrc;
+  prevDDRD = ddrd;
+
+  // Check Special Button Combinations
+  // Change Profile
+  if((ddrd & DDRD_COIN) && (ddrc & DDRC_UP)) {
+    if(ps3.Connected()) { // PS3
+      SetProfile(ps3, BUILT_IN_PROFILES);
+    } else if (xbox.Connected()) { // XboxOne
+      SetProfile(xbox, BUILT_IN_PROFILES);
+    }
+    return;
+  }
+  // Output
+  DDRC = ddrc;
+  DDRD = ddrd;
+
+  debugOutput(ddrc, ddrd);
+}
+
+void USB2DB15::GenerateBuiltinProfiles() {
+  GenerateDefaultProfile(profiles[0]);
+  GenerateRowSwapProfile(profiles[1], profiles[0]);
+  GenerateSnesProfile(profiles[2], profiles[0]);
+  GenerateRowSwapProfile(profiles[3], profiles[2]);
+}
+
+void USB2DB15::GenerateDefaultProfile(Profile &profile) {
+  profile.SetButton(BUTTON_UP, PROFILE_BUTTON_UP);
+  profile.SetButton(BUTTON_RIGHT, PROFILE_BUTTON_RIGHT);
+  profile.SetButton(BUTTON_DOWN, PROFILE_BUTTON_DOWN);
+  profile.SetButton(BUTTON_LEFT, PROFILE_BUTTON_LEFT);
+  profile.SetButton(BUTTON_START, PROFILE_BUTTON_START);
+  profile.SetButton(BUTTON_COIN, PROFILE_BUTTON_COIN);
+  profile.SetButton(BUTTON_1, PROFILE_BUTTON_1);
+  profile.SetButton(BUTTON_2, PROFILE_BUTTON_2);
+  profile.SetButton(BUTTON_3, PROFILE_BUTTON_3);
+  profile.SetButton(BUTTON_4, PROFILE_BUTTON_4);
+  profile.SetButton(BUTTON_5, PROFILE_BUTTON_5);
+  profile.SetButton(BUTTON_6, PROFILE_BUTTON_6);
+}
+
+void USB2DB15::GenerateRowSwapProfile(Profile &profile, Profile &base) {
+  profile.Copy(base);
+  profile.SwapButtons(PROFILE_BUTTON_1, PROFILE_BUTTON_4);
+  profile.SwapButtons(PROFILE_BUTTON_2, PROFILE_BUTTON_5);
+  profile.SwapButtons(PROFILE_BUTTON_3, PROFILE_BUTTON_6);
+}
+
+void USB2DB15::GenerateSnesProfile(Profile &profile, Profile &base) {
+  profile.Copy(base);
+  profile.SetButton(BUTTON_7, PROFILE_BUTTON_6);
+}
+
+uint8_t USB2DB15::GetDDRC(Profile &profile, Controller &controller) {
+  uint8_t ddrc = 0;
+
+  if(controller.GetButtonState(profile.bindings[PROFILE_BUTTON_UP])) {
+    ddrc |= DDRC_UP;
+  }
+
+  if(controller.GetButtonState(profile.bindings[PROFILE_BUTTON_LEFT])) {
+    ddrc |= DDRC_LEFT;
+  }
+
+  if(controller.GetButtonState(profile.bindings[PROFILE_BUTTON_1])) {
+    ddrc |= DDRC_1;
+  }
+
+  if(controller.GetButtonState(profile.bindings[PROFILE_BUTTON_3])) {
+    ddrc |= DDRC_3;
+  }
+
+  if(controller.GetButtonState(profile.bindings[PROFILE_BUTTON_6])) {
+    ddrc |= DDRC_6;
+  }
+
+  if(controller.GetButtonState(profile.bindings[PROFILE_BUTTON_START])) {
+    ddrc |= DDRC_START;
+  }
+
+  return ddrc;
+}
+
+uint8_t USB2DB15::GetDDRD(Profile &profile, Controller &controller) {
+  uint8_t ddrd = 0;
+
+  if(controller.GetButtonState(profile.bindings[PROFILE_BUTTON_RIGHT])) {
+    ddrd |= DDRD_RIGHT;
+  }
+
+  if(controller.GetButtonState(profile.bindings[PROFILE_BUTTON_DOWN])) {
+    ddrd |= DDRD_DOWN;
+  }
+
+  if(controller.GetButtonState(profile.bindings[PROFILE_BUTTON_2])) {
+    ddrd |= DDRD_2;
+  }
+
+  if(controller.GetButtonState(profile.bindings[PROFILE_BUTTON_4])) {
+    ddrd |= DDRD_4;
+  }
+
+  if(controller.GetButtonState(profile.bindings[PROFILE_BUTTON_5])) {
+    ddrd |= DDRD_5;
+  }
+
+  if(controller.GetButtonState(profile.bindings[PROFILE_BUTTON_COIN])) {
+    ddrd |= DDRD_COIN;
+  }
+
+  return ddrd;
+}
+
+// Gets the number of the lowest index button pressed
+void USB2DB15::SetProfile(Controller &controller, uint8_t page) {
+  if(controller.GetButtonState(profiles[0].bindings[PROFILE_BUTTON_1])) {
+    Serial.print("Using Profile: ");
+    Serial.println((0 + page * 6));
+    curProfile = 0 + page * 6;
+  }
+
+  if(controller.GetButtonState(profiles[0].bindings[PROFILE_BUTTON_2])) {
+    Serial.print("Using Profile: ");
+    Serial.println((1 + page * 6));
+    curProfile = 1 + page * 6;
+  }
+
+  if(controller.GetButtonState(profiles[0].bindings[PROFILE_BUTTON_3])) {
+    Serial.print("Using Profile: ");
+    Serial.println((2 + page * 6));
+    curProfile = 2 + page * 6;
+  }
+
+  if(controller.GetButtonState(profiles[0].bindings[PROFILE_BUTTON_4])) {
+    Serial.print("Using Profile: ");
+    Serial.println((3 + page * 6));
+    curProfile = 3 + page * 6;
+  }
+  // if(ddrd & DDRD_5) return curProfile = 0;
+  // if(ddrc & DDRC_6) return curProfile = 0;
+}

--- a/RFUSB_to_DB15/USB2DB15.h
+++ b/RFUSB_to_DB15/USB2DB15.h
@@ -1,0 +1,61 @@
+//
+// Created by Kitsune on 8/21/2020.
+//
+
+#ifndef USB2DB15_USB2DB15_H
+#define USB2DB15_USB2DB15_H
+
+#include <stdint.h>
+
+#include "controller.h"
+#include "device_descriptor.h"
+#include "Profile.h"
+#include "PS3Controller.h"
+#include "XBoxOneController.h"
+
+// Output Constants
+/* DDRC */
+#define DDRC_3      1   //A0
+#define DDRC_1      2   //A1
+#define DDRC_LEFT   4   //A2
+#define DDRC_UP     8   //A3
+#define DDRC_6      16  //A4
+#define DDRC_START  32  //A5
+
+/* DDRD */
+#define DDRD_DOWN   4   //D2
+#define DDRD_RIGHT  8   //D3
+#define DDRD_2      16  //D4
+#define DDRD_4      32  //D5
+#define DDRD_COIN   64  //D6
+#define DDRD_5      128 //D7
+
+/* Profile Pages */
+#define BUILT_IN_PROFILES 0
+
+
+
+class USB2DB15 {
+  PS3Controller &ps3;
+  XBoxOneController &xbox;
+  Profile profiles[6];
+  uint8_t curProfile = 1;
+  uint8_t prevDDRC = 0;
+  uint8_t prevDDRD = 0;
+
+public:
+  USB2DB15(PS3Controller &ps3, XBoxOneController &xbox);
+  void GenerateOutput();
+
+protected:
+  void GenerateBuiltinProfiles();
+  void GenerateDefaultProfile(Profile &profile);
+  void GenerateRowSwapProfile(Profile &profile, Profile &base);
+  void GenerateSnesProfile(Profile &profile, Profile &base);
+  uint8_t GetDDRC(Profile &profile, Controller &controller);
+  uint8_t GetDDRD(Profile &profile, Controller &controller);
+  void SetProfile(Controller &controller, uint8_t page);
+};
+
+
+#endif //USB2DB15_USB2DB15_H

--- a/RFUSB_to_DB15/XBoxOneController.cpp
+++ b/RFUSB_to_DB15/XBoxOneController.cpp
@@ -1,0 +1,52 @@
+//
+// Created by Kitsune on 8/21/2020.
+//
+
+#include "XBoxOneController.h"
+#include "device_descriptor.h"
+
+XBoxOneController::XBoxOneController(XBOXONE *p) {
+  xbox = p;
+}
+
+bool XBoxOneController::GetButtonState(uint8_t button) {
+  switch(button) {
+    case BUTTON_UP:
+      return xbox->getButtonPress(UP);
+    case BUTTON_DOWN:
+      return xbox->getButtonPress(DOWN);
+    case BUTTON_LEFT:
+      return xbox->getButtonPress(LEFT);
+    case BUTTON_RIGHT:
+      return xbox->getButtonPress(RIGHT);
+    case BUTTON_START:
+      return xbox->getButtonPress(START);
+    case BUTTON_COIN:
+      return xbox->getButtonPress(BACK);
+    case BUTTON_1:
+      return xbox->getButtonPress(A);
+    case BUTTON_2:
+      return xbox->getButtonPress(B);
+    case BUTTON_3:
+      return xbox->getButtonPress(R2);
+    case BUTTON_4:
+      return xbox->getButtonPress(X);
+    case BUTTON_5:
+      return xbox->getButtonPress(Y);
+    case BUTTON_6:
+      return xbox->getButtonPress(R1);
+    case BUTTON_7:
+      return xbox->getButtonPress(L1);
+    case BUTTON_8:
+      return xbox->getButtonPress(L2);
+    case BUTTON_9:
+      return xbox->getButtonPress(R3);
+    case BUTTON_10:
+      return xbox->getButtonPress(L3);
+  }
+  return false;
+}
+
+bool XBoxOneController::Connected() {
+  return xbox->XboxOneConnected;
+}

--- a/RFUSB_to_DB15/XBoxOneController.h
+++ b/RFUSB_to_DB15/XBoxOneController.h
@@ -1,0 +1,21 @@
+//
+// Created by Kitsune on 8/21/2020.
+//
+
+#ifndef USB2DB15_XBOXONECONTROLLER_H
+#define USB2DB15_XBOXONECONTROLLER_H
+
+#include <XBOXONE.h>
+#include "Controller.h"
+
+class XBoxOneController : public Controller {
+  XBOXONE *xbox;
+
+public:
+  XBoxOneController(XBOXONE *p);
+
+  bool GetButtonState(uint8_t button);
+  bool Connected();
+};
+
+#endif //USB2DB15_XBOXONECONTROLLER_H

--- a/RFUSB_to_DB15/device_descriptor.h
+++ b/RFUSB_to_DB15/device_descriptor.h
@@ -1,0 +1,49 @@
+//
+// Created by Kitsune on 8/21/2020.
+//
+
+#ifndef USB2DB15_DEVICE_DESCRIPTOR_H
+#define USB2DB15_DEVICE_DESCRIPTOR_H
+
+// Button Types
+#define BUTTON_SINGLE 0
+#define BUTTON_DPAD 1
+#define BUTTON_DIRECTIONAL 2
+
+// Directional Constants/D-Pad Directions
+#define DIR_UP 0
+#define DIR_UP_RIGHT 1
+#define DIR_RIGHT 2
+#define DIR_DOWN_RIGHT 3
+#define DIR_DOWN 4
+#define DIR_DOWN_LEFT 5
+#define DIR_LEFT 6
+#define DIR_UP_LEFT 7
+
+// Directional Digital Constants
+#define DIR_MAX = 0xFF
+#define DIR_MIX = 0x00
+
+// Common Button Ids
+#define BUTTON_UP         0
+#define BUTTON_UP_RIGHT   1
+#define BUTTON_RIGHT      2
+#define BUTTON_DOWN_RIGHT 3
+#define BUTTON_DOWN       4
+#define BUTTON_DOWN_LEFT  5
+#define BUTTON_LEFT       6
+#define BUTTON_UP_LEFT    7
+#define BUTTON_START      8
+#define BUTTON_COIN       9   // Select, Back
+#define BUTTON_1          10  // A, Square
+#define BUTTON_2          11  // B, Triangle
+#define BUTTON_3          12  // C, R1
+#define BUTTON_4          13  // X, X
+#define BUTTON_5          15  // Y, Circle
+#define BUTTON_6          16  // Z, R2
+#define BUTTON_7          17  // L1
+#define BUTTON_8          18  // L2
+#define BUTTON_9          19  // R3
+#define BUTTON_10         20  // L3
+
+#endif //USB2DB15_DEVICE_DESCRIPTOR_H


### PR DESCRIPTION
This PR does a number of things:
It creates a Generic Controller class which is used to create a consistent Interface for button presses
It creates a XboxOne and PS3USB controller classes that implement the Generic controller
It creates 4 built in profiles which are accessible via UP + SELECT + BUTTON n for the nth profile
It creates the USB2DB15 class to coordinate all of this.