### PR TITLE
Kitsune user defined profiles

### DIFF
--- a/RFUSB_to_DB15/Controller.h
+++ b/RFUSB_to_DB15/Controller.h
@@ -16,7 +16,8 @@
  */
 class Controller {
 public:
-  virtual bool GetButtonState(uint8_t button);
+  virtual bool GetButtonClick(uint8_t button); // Only returns true once per button press
+  virtual bool GetButtonState(uint8_t button); // returns true if the button is currently pressed
   virtual bool Connected();
 };
 

--- a/RFUSB_to_DB15/EepromManager.cpp
+++ b/RFUSB_to_DB15/EepromManager.cpp
@@ -2,7 +2,6 @@
 // Created by Kitsune on 8/26/2020.
 //
 #include <EEPROM.h>
-#include <SPI.h>
 
 #include "device_descriptor.h"
 #include "EepromManager.h"

--- a/RFUSB_to_DB15/EepromManager.cpp
+++ b/RFUSB_to_DB15/EepromManager.cpp
@@ -2,6 +2,7 @@
 // Created by Kitsune on 8/26/2020.
 //
 #include <EEPROM.h>
+#include <SPI.h>
 
 #include "device_descriptor.h"
 #include "EepromManager.h"
@@ -23,14 +24,14 @@ EepromManager::EepromManager() {
  * Initialize the EEPROM with default values
  */
 void EepromManager::Initialize() {
-  //Create the header
+  // Populate initial profiles
+  GenerateInitialProfiles();
+
+  //Create the header last only after everything completes
   EEPROM.update(0, EEPROM_BYTE_0);
   EEPROM.update(1, EEPROM_BYTE_1);
   EEPROM.update(2, EEPROM_BYTE_2);
   EEPROM.update(3, EEPROM_VERISON);
-
-  // Populate initial profiles
-  GenerateInitialProfiles();
 }
 
 /**

--- a/RFUSB_to_DB15/EepromManager.cpp
+++ b/RFUSB_to_DB15/EepromManager.cpp
@@ -1,0 +1,134 @@
+//
+// Created by Kitsune on 8/26/2020.
+//
+#include <EEPROM.h>
+
+#include "device_descriptor.h"
+#include "EepromManager.h"
+
+EepromManager::EepromManager() {
+  if(EEPROM.read(0) != EEPROM_BYTE_0 ||
+     EEPROM.read(1) != EEPROM_BYTE_1 ||
+     EEPROM.read(2) != EEPROM_BYTE_2) {
+    Initialize();
+  }
+
+  // We may want to attempt to migrate the data so new versions in the future so I have separated this check out
+  if(EEPROM.read(3) != EEPROM_VERISON) {
+    Initialize();
+  }
+}
+
+/**
+ * Initialize the EEPROM with default values
+ */
+void EepromManager::Initialize() {
+  //Create the header
+  EEPROM.update(0, EEPROM_BYTE_0);
+  EEPROM.update(1, EEPROM_BYTE_1);
+  EEPROM.update(2, EEPROM_BYTE_2);
+  EEPROM.update(3, EEPROM_VERISON);
+
+  // Populate initial profiles
+  GenerateInitialProfiles();
+}
+
+/**
+ * Loads the current profile number from EEPROM
+ * @return The profile number
+ */
+uint8_t EepromManager::LoadCurrentProfile() {
+  return EEPROM.read(CURRENT_PROFILE_ADDR);
+}
+
+/**
+ * Saves the current profile number to EEPROM
+ * @param num The Current Profile Number
+ */
+void EepromManager::SaveCurrentProfile(uint8_t num) {
+  EEPROM.update(CURRENT_PROFILE_ADDR, num);
+}
+
+/**
+ * Loads the specified profile from EEPROM into the given profile object
+ * @param num The number of the profile to load
+ * @param profile The profile object to load the profile into
+ */
+void EepromManager::LoadProfile(uint8_t num, Profile &profile) {
+  int start_addr = PROFILE_START_ADDR + (num * PROFILE_SIZE);
+  if (num >= MAX_PROFILES) return;
+
+  for(uint8_t i;i < NUM_BUTTON_BINDINGS; i++) {
+    profile.bindings[i] = EEPROM.read(start_addr + i);
+  }
+}
+
+void EepromManager::SaveProfile(uint8_t num, Profile &profile) {
+  int start_addr = PROFILE_START_ADDR + (num * PROFILE_SIZE);
+  if (num >= MAX_PROFILES) return;
+
+  for(uint8_t i;i < NUM_BUTTON_BINDINGS; i++) {
+    EEPROM.update(start_addr + i, profile.bindings[i]);
+  }
+}
+
+void EepromManager::GenerateInitialProfiles() {
+  Profile profile;
+
+  // Profile 0 is the default profile
+  GenerateDefaultProfile(profile);
+  SaveProfile(0, profile);
+
+  // Profile 1 is the default profile row swapped
+  SwapProfileRows(profile);
+  SaveProfile(1, profile);
+
+  // Profile 2 is the Default profile but with L1 instead of R2
+  GenerateDefaultProfile(profile);
+  profile.SetButton(BUTTON_7, PROFILE_BUTTON_6);
+  SaveProfile(2, profile);
+
+  // Profile 3 is Profile 2 with the rows swapped
+  SwapProfileRows(profile);
+  SaveProfile(3, profile);
+
+  // Profile 4 - n haven't been decided yet and are default
+  GenerateDefaultProfile(profile);
+  for(uint8_t i = 4; i < MAX_PROFILES; i++) {
+    SaveProfile(i, profile);
+  }
+}
+
+/**
+ * Creates a Default profile.
+ * @param profile The profile slot to store the profile in
+ */
+void EepromManager::GenerateDefaultProfile(Profile &profile) {
+  profile.SetButton(BUTTON_UP, PROFILE_BUTTON_UP);
+  profile.SetButton(BUTTON_RIGHT, PROFILE_BUTTON_RIGHT);
+  profile.SetButton(BUTTON_DOWN, PROFILE_BUTTON_DOWN);
+  profile.SetButton(BUTTON_LEFT, PROFILE_BUTTON_LEFT);
+  profile.SetButton(BUTTON_START, PROFILE_BUTTON_START);
+  profile.SetButton(BUTTON_COIN, PROFILE_BUTTON_COIN);
+  profile.SetButton(BUTTON_1, PROFILE_BUTTON_1);
+  profile.SetButton(BUTTON_2, PROFILE_BUTTON_2);
+  profile.SetButton(BUTTON_3, PROFILE_BUTTON_3);
+  profile.SetButton(BUTTON_4, PROFILE_BUTTON_4);
+  profile.SetButton(BUTTON_5, PROFILE_BUTTON_5);
+  profile.SetButton(BUTTON_6, PROFILE_BUTTON_6);
+}
+
+/**
+ * Swaps a profiles top and bottom rows
+ *
+ * It accomplishes this swap by swapping buttons 1 with 4, 2 with 5,
+ * and 3 with 6
+ *
+ * @param profile The profile slot to store the profile in
+ * @param base The profile slot to copy from
+ */
+void EepromManager::SwapProfileRows(Profile &profile) {
+  profile.SwapButtons(PROFILE_BUTTON_1, PROFILE_BUTTON_4);
+  profile.SwapButtons(PROFILE_BUTTON_2, PROFILE_BUTTON_5);
+  profile.SwapButtons(PROFILE_BUTTON_3, PROFILE_BUTTON_6);
+}

--- a/RFUSB_to_DB15/EepromManager.h
+++ b/RFUSB_to_DB15/EepromManager.h
@@ -17,8 +17,29 @@
  * bytes    Description
  * 0-2      'U2N' in ascii.  This tells us if the EEPROM has been initialized
  * 3        Version number in binary. Tells us what EEPROM layout we are using
- * 4-5      Reserved
+ * 4-5      Reserved for future use
  * 6        Current Profile Number
+ * 7        Current Number of Custom Device Descriptors
+ * 8-19     Reserved for future use
+ * 20-199   Profiles (10 profiles at 18 bytes each = 180)
+ */
+
+/**
+ * Profile Layout  (Byte Address is the same as the Profile IDs in profile.h
+ * Byte     Description
+ * 0        UP
+ * 1        RIGHT
+ * 2        DOWN
+ * 3        LEFT
+ * 4        START
+ * 5        COIN/SELECT
+ * 6        BUTTON 1
+ * 7        BUTTON 2
+ * 8        BUTTON 3
+ * 9        BUTTON 4
+ * 10       BUTTON 5
+ * 11       BUTTON 6
+ * 12-15    Reserved reserved for future use
  */
 
 // Address Locations

--- a/RFUSB_to_DB15/EepromManager.h
+++ b/RFUSB_to_DB15/EepromManager.h
@@ -1,0 +1,49 @@
+//
+// Created by Kitsune on 8/26/2020.
+//
+
+#ifndef USB2DB15_EEPROMMANAGER_H
+#define USB2DB15_EEPROMMANAGER_H
+
+#include "Profile.h"
+
+#define EEPROM_BYTE_0 'U'
+#define EEPROM_BYTE_1 '2'
+#define EEPROM_BYTE_2 'N'
+#define EEPROM_VERISON 1
+
+/**
+ * EEPROM Layout
+ * bytes    Description
+ * 0-2      'U2N' in ascii.  This tells us if the EEPROM has been initialized
+ * 3        Version number in binary. Tells us what EEPROM layout we are using
+ * 4-5      Reserved
+ * 6        Current Profile Number
+ */
+
+// Address Locations
+
+#define CURRENT_PROFILE_ADDR 6
+#define PROFILE_START_ADDR 20
+#define PROFILE_SIZE 18
+#define MAX_PROFILES 10
+
+class EepromManager {
+public:
+  EepromManager();
+  void Initialize();
+
+  void LoadProfile(uint8_t num, Profile &profile);
+  void SaveProfile(uint8_t num, Profile &profile);
+
+  uint8_t LoadCurrentProfile();
+  void SaveCurrentProfile(uint8_t num);
+
+protected:
+  void GenerateInitialProfiles();
+  void GenerateDefaultProfile(Profile &profile);
+  void SwapProfileRows(Profile &profile);
+};
+
+
+#endif //USB2DB15_EEPROMMANAGER_H

--- a/RFUSB_to_DB15/HIDController.cpp
+++ b/RFUSB_to_DB15/HIDController.cpp
@@ -15,6 +15,62 @@ bool HIDController::Connected() {
 }
 
 /**
+ * Gets if the button has been clicked since the last check
+ *
+ * This function checks the buttonState variable to see if the bit
+ * corresponding to the button is set to true. Then checked lastButtonState
+ * to make sure it wasn't previously pressed.
+ *
+ * @param button The button to check. Defined in "device_description.h"
+ * @return If the requested button is pressed
+ */
+bool HIDController::GetButtonClick(uint8_t button) {
+  switch (button) {
+    case BUTTON_UP :
+      return (buttonState & MASK_UP) && !(lastButtonState & MASK_UP);
+    case BUTTON_DOWN :
+      return (buttonState & MASK_DOWN) && !(lastButtonState & MASK_DOWN);
+    case BUTTON_RIGHT :
+      return (buttonState & MASK_RIGHT) && !(lastButtonState & MASK_RIGHT);
+    case BUTTON_LEFT :
+      return (buttonState & MASK_LEFT) && !(lastButtonState & MASK_LEFT);
+    case BUTTON_UP_RIGHT :
+      return (buttonState & MASK_UP_RIGHT) && !(lastButtonState & MASK_UP_RIGHT);
+    case BUTTON_DOWN_RIGHT :
+      return (buttonState & MASK_DOWN_RIGHT) && !(lastButtonState & MASK_DOWN_RIGHT);
+    case BUTTON_DOWN_LEFT :
+      return (buttonState & MASK_DOWN_LEFT) && !(lastButtonState & MASK_DOWN_LEFT);
+    case BUTTON_UP_LEFT :
+      return (buttonState & MASK_UP_LEFT) && !(lastButtonState & MASK_UP_LEFT);
+    case BUTTON_COIN :
+      return (buttonState & MASK_COIN) && !(lastButtonState & MASK_COIN);
+    case BUTTON_START :
+      return (buttonState & MASK_START) && !(lastButtonState & MASK_START);
+    case BUTTON_1 :
+      return (buttonState & MASK_BUTTON_1) && !(lastButtonState & MASK_BUTTON_1);
+    case BUTTON_2 :
+      return (buttonState & MASK_BUTTON_2) && !(lastButtonState & MASK_BUTTON_2);
+    case BUTTON_3 :
+      return (buttonState & MASK_BUTTON_3) && !(lastButtonState & MASK_BUTTON_3);
+    case BUTTON_4 :
+      return (buttonState & MASK_BUTTON_4) && !(lastButtonState & MASK_BUTTON_4);
+    case BUTTON_5 :
+      return (buttonState & MASK_BUTTON_5) && !(lastButtonState & MASK_BUTTON_5);
+    case BUTTON_6 :
+      return (buttonState & MASK_BUTTON_6) && !(lastButtonState & MASK_BUTTON_6);
+    case BUTTON_7 :
+      return (buttonState & MASK_BUTTON_7) && !(lastButtonState & MASK_BUTTON_7);
+    case BUTTON_8 :
+      return (buttonState & MASK_BUTTON_8) && !(lastButtonState & MASK_BUTTON_8);
+    case BUTTON_9 :
+      return (buttonState & MASK_BUTTON_9) && !(lastButtonState & MASK_BUTTON_9);
+    case BUTTON_10 :
+      return (buttonState & MASK_BUTTON_10) && !(lastButtonState & MASK_BUTTON_10);
+  }
+  return 0;
+}
+
+/**
  * Gets the State(pressed or not) of a given button
  *
  * This function checks the buttonState variable to see if the bit
@@ -141,8 +197,10 @@ uint8_t HIDController::OnInitSuccessful() {
  * @param buf The buffer
  */
 void HIDController::ParseHIDData(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
-  buttonState = 0;
   uint8_t value = 0;
+
+  lastButtonState = buttonState;
+  buttonState = 0;
 
   // For each button shift left then append the button state
   // UP is the left most bit, BUTTON_10 is right most

--- a/RFUSB_to_DB15/HIDController.h
+++ b/RFUSB_to_DB15/HIDController.h
@@ -47,7 +47,7 @@ struct Button {
 // Multiple Inheritance solves data sharing problems here, but can be slow
 class HIDController : public HIDUniversal, public Controller {
   Button buttons[MAX_HID_BUTTONS];
-  uint32_t buttonState, lastButtonState;
+  uint32_t buttonState, lastButtonState, clickState;
 
 public:
   HIDController(USB *usb) : HIDUniversal(usb), Controller() {};

--- a/RFUSB_to_DB15/HIDController.h
+++ b/RFUSB_to_DB15/HIDController.h
@@ -47,7 +47,7 @@ struct Button {
 // Multiple Inheritance solves data sharing problems here, but can be slow
 class HIDController : public HIDUniversal, public Controller {
   Button buttons[MAX_HID_BUTTONS];
-  uint32_t buttonState;
+  uint32_t buttonState, lastButtonState;
 
 public:
   HIDController(USB *usb) : HIDUniversal(usb), Controller() {};
@@ -56,6 +56,7 @@ public:
   void ConfigButton(uint8_t button_id, uint8_t index, uint8_t mask, uint8_t value);
 
   bool Connected();
+  bool GetButtonClick(uint8_t button);
   bool GetButtonState(uint8_t button);
 
 protected:

--- a/RFUSB_to_DB15/PS3Controller.cpp
+++ b/RFUSB_to_DB15/PS3Controller.cpp
@@ -15,6 +15,54 @@ PS3Controller::PS3Controller(PS3USB *p) {
 }
 
 /**
+ * Gets if the button has been clicked since the last check
+ *
+ * This function uses the aliases provide by the Host Shield Library
+ * to determine if a given button has been clicked. Only returns true
+ * once per button press
+ *
+ * @param button The button to check. Defined in "device_description.h"
+ * @return If the button has been clicked
+ */
+bool PS3Controller::GetButtonClick(uint8_t button) {
+  switch(button) {
+    case BUTTON_UP:
+      return ps3usb->getButtonClick(UP);
+    case BUTTON_DOWN:
+      return ps3usb->getButtonClick(DOWN);
+    case BUTTON_LEFT:
+      return ps3usb->getButtonClick(LEFT);
+    case BUTTON_RIGHT:
+      return ps3usb->getButtonClick(RIGHT);
+    case BUTTON_START:
+      return ps3usb->getButtonClick(START);
+    case BUTTON_COIN:
+      return ps3usb->getButtonClick(BACK);
+    case BUTTON_1:
+      return ps3usb->getButtonClick(SQUARE);
+    case BUTTON_2:
+      return ps3usb->getButtonClick(TRIANGLE);
+    case BUTTON_3:
+      return ps3usb->getButtonClick(R1);
+    case BUTTON_4:
+      return ps3usb->getButtonClick(X);
+    case BUTTON_5:
+      return ps3usb->getButtonClick(CIRCLE);
+    case BUTTON_6:
+      return ps3usb->getButtonClick(R2);
+    case BUTTON_7:
+      return ps3usb->getButtonClick(L1);
+    case BUTTON_8:
+      return ps3usb->getButtonClick(L2);
+    case BUTTON_9:
+      return ps3usb->getButtonClick(R3);
+    case BUTTON_10:
+      return ps3usb->getButtonClick(L3);
+  }
+  return false;
+}
+
+/**
  * Gets the State(pressed or not) of a given button
  *
  * This function uses the aliases provide by the Host Shield Library

--- a/RFUSB_to_DB15/PS3Controller.h
+++ b/RFUSB_to_DB15/PS3Controller.h
@@ -19,6 +19,7 @@ class PS3Controller : public Controller {
 public:
   PS3Controller(PS3USB *p);
 
+  bool GetButtonClick(uint8_t button);
   bool GetButtonState(uint8_t button);
   bool Connected();
 };

--- a/RFUSB_to_DB15/RFUSB_to_DB15.ino
+++ b/RFUSB_to_DB15/RFUSB_to_DB15.ino
@@ -45,6 +45,7 @@
 #include <usbhid.h>
 #include <hiduniversal.h>
 
+#include "EepromManager.h"
 #include "HIDController.h"
 #include "PS3Controller.h"
 #include "XBoxOneController.h"
@@ -73,10 +74,11 @@ USB Usb;
 PS3USB PS3(&Usb);
 XBOXONE Xbox(&Usb);
 
+EepromManager Eeprom;
 HIDController HIDCon(&Usb);
 PS3Controller PS3Con(&PS3);
 XBoxOneController XBoxCon(&Xbox);
-USB2DB15 Usb2db15(PS3Con, XBoxCon, HIDCon);
+USB2DB15 Usb2db15(PS3Con, XBoxCon, HIDCon, Eeprom);
 
 
 // JoystickHID Hid1(&Usb);

--- a/RFUSB_to_DB15/USB2DB15.cpp
+++ b/RFUSB_to_DB15/USB2DB15.cpp
@@ -214,6 +214,15 @@ uint8_t USB2DB15::GetDDRD(Controller &controller) {
   return ddrd;
 }
 
+/**
+ * Handles Input in the Normal Mode Context
+ *
+ * This mode will check for profile change commands and update the DB15 pins
+ *
+ * @param ddrc the data to send to DDRC
+ * @param ddrd the data to send to DDRD
+ * @param controller The controller pull raw input from
+ */
 void USB2DB15::HandleNormalMode(uint8_t ddrc, uint8_t ddrd, Controller &controller) {
   if (ddrc == prevDDRC && ddrd == prevDDRD) return;
   // Check Special Button Combinations
@@ -229,6 +238,15 @@ void USB2DB15::HandleNormalMode(uint8_t ddrc, uint8_t ddrd, Controller &controll
   debugOutput(ddrc, ddrd);
 }
 
+/**
+ * Handles Inpute in the Profile Rebinding Context
+ *
+ * Handles setting up User Defined Profiles.
+ *
+ * @param ddrc the data to send to DDRC
+ * @param ddrd the data to send to DDRD
+ * @param controller The controller pull raw input from
+ */
 void USB2DB15::HandleProfileBindMode(uint8_t ddrc, uint8_t ddrd, Controller &controller) {
   // End Mode if SELECT/COIN is released
   if(!(ddrd & DDRD_COIN)) {

--- a/RFUSB_to_DB15/USB2DB15.h
+++ b/RFUSB_to_DB15/USB2DB15.h
@@ -1,7 +1,6 @@
 //
 // Created by Kitsune on 8/21/2020.
 //
-#include <EEPROM.h>
 #ifndef USB2DB15_USB2DB15_H
 #define USB2DB15_USB2DB15_H
 
@@ -9,6 +8,7 @@
 
 #include "controller.h"
 #include "device_descriptor.h"
+#include "EepromManager.h"
 #include "Profile.h"
 #include "PS3Controller.h"
 #include "XBoxOneController.h"
@@ -48,23 +48,19 @@ class USB2DB15 {
     PS3Controller &ps3;
     XBoxOneController &xbox;
     HIDController &hid;
-    Profile profiles[6];
-    uint8_t curProfile = 0;
+    EepromManager &eeprom;
+    Profile profile;
     uint8_t prevDDRC = 0;
     uint8_t prevDDRD = 0;
 
   public:
-    USB2DB15(PS3Controller &ps3, XBoxOneController &xbox, HIDController &hid);
+    USB2DB15(PS3Controller &ps3, XBoxOneController &xbox, HIDController &hid, EepromManager &eeprom);
     void GenerateOutput();
 
   protected:
-    void GenerateBuiltinProfiles();
-    void GenerateDefaultProfile(Profile &profile);
-    void GenerateRowSwapProfile(Profile &profile, Profile &base);
-    void GenerateSnesProfile(Profile &profile, Profile &base);
-    uint8_t GetDDRC(Profile &profile, Controller &controller);
-    uint8_t GetDDRD(Profile &profile, Controller &controller);
-    void SetProfile(Controller &controller, uint8_t page);
+    uint8_t GetDDRC(Controller &controller);
+    uint8_t GetDDRD(Controller &controller);
+    void SetProfile(Controller &controller);
 };
 
 

--- a/RFUSB_to_DB15/USB2DB15.h
+++ b/RFUSB_to_DB15/USB2DB15.h
@@ -31,11 +31,12 @@
 #define DDRD_COIN   64  //D6
 #define DDRD_5      128 //D7
 
-/* Profile Pages */
-#define BUILT_IN_PROFILES 0
+/* Durations */
+#define SELECT_HOLD_DURATION 3000
 
-/* EEPROM Locations */
-#define CURRENT_PROFILE_ADDR 6
+/* Input Modes */
+#define NORMAL_MODE 0
+#define PROFILE_BIND_MODE 1
 
 /**
  * USB To DB15
@@ -52,6 +53,9 @@ class USB2DB15 {
     Profile profile;
     uint8_t prevDDRC = 0;
     uint8_t prevDDRD = 0;
+    uint8_t input_mode = NORMAL_MODE;
+    uint8_t cur_key = 0;
+    unsigned long select_press_time = 0;
 
   public:
     USB2DB15(PS3Controller &ps3, XBoxOneController &xbox, HIDController &hid, EepromManager &eeprom);
@@ -61,6 +65,8 @@ class USB2DB15 {
     uint8_t GetDDRC(Controller &controller);
     uint8_t GetDDRD(Controller &controller);
     void SetProfile(Controller &controller);
+    void HandleNormalMode(uint8_t ddrc, uint8_t ddrd, Controller &controller);
+    void HandleProfileBindMode(uint8_t ddrc, uint8_t ddrd, Controller &controller);
 };
 
 

--- a/RFUSB_to_DB15/XBoxOneController.cpp
+++ b/RFUSB_to_DB15/XBoxOneController.cpp
@@ -24,7 +24,7 @@ XBoxOneController::XBoxOneController(XBOXONE *p) {
  * @param button The button to check. Defined in "device_description.h"
  * @return If the button has been clicked
  */
-bool GetButtonClick(uint8_t button) {
+bool XBoxOneController::GetButtonClick(uint8_t button) {
   switch(button) {
     case BUTTON_UP:
       return xbox->getButtonClick(UP);

--- a/RFUSB_to_DB15/XBoxOneController.cpp
+++ b/RFUSB_to_DB15/XBoxOneController.cpp
@@ -15,6 +15,54 @@ XBoxOneController::XBoxOneController(XBOXONE *p) {
 }
 
 /**
+ * Gets if the button has been clicked since the last check
+ *
+ * This function uses the aliases provide by the Host Shield Library
+ * to determine if a given button has been clicked. Only returns true
+ * once per button press
+ *
+ * @param button The button to check. Defined in "device_description.h"
+ * @return If the button has been clicked
+ */
+bool GetButtonClick(uint8_t button) {
+  switch(button) {
+    case BUTTON_UP:
+      return xbox->getButtonClick(UP);
+    case BUTTON_DOWN:
+      return xbox->getButtonClick(DOWN);
+    case BUTTON_LEFT:
+      return xbox->getButtonClick(LEFT);
+    case BUTTON_RIGHT:
+      return xbox->getButtonClick(RIGHT);
+    case BUTTON_START:
+      return xbox->getButtonClick(START);
+    case BUTTON_COIN:
+      return xbox->getButtonClick(BACK);
+    case BUTTON_1:
+      return xbox->getButtonClick(A);
+    case BUTTON_2:
+      return xbox->getButtonClick(B);
+    case BUTTON_3:
+      return xbox->getButtonClick(R2);
+    case BUTTON_4:
+      return xbox->getButtonClick(X);
+    case BUTTON_5:
+      return xbox->getButtonClick(Y);
+    case BUTTON_6:
+      return xbox->getButtonClick(R1);
+    case BUTTON_7:
+      return xbox->getButtonClick(L1);
+    case BUTTON_8:
+      return xbox->getButtonClick(L2);
+    case BUTTON_9:
+      return xbox->getButtonClick(R3);
+    case BUTTON_10:
+      return xbox->getButtonClick(L3);
+  }
+  return false;
+}
+
+/**
  * Gets the State(pressed or not) of a given button
  *
  * This function uses the aliases provide by the Host Shield Library

--- a/RFUSB_to_DB15/XBoxOneController.h
+++ b/RFUSB_to_DB15/XBoxOneController.h
@@ -20,6 +20,7 @@ class XBoxOneController : public Controller {
 public:
   XBoxOneController(XBOXONE *p);
 
+  bool GetButtonClick(uint8_t button);
   bool GetButtonState(uint8_t button);
   bool Connected();
 };


### PR DESCRIPTION
Adds support for user defined profiles.  In order to do this it makes the following changes:
- Profiles are now stored in EEPROM
- A new EepromManager class is added. It initializes the EEPROM with default values and Manages Access to the EEPROM
- Added a GetButtonClick function to Controller.  It returned true only once each time a button is pressed.
- Implemented GetButtonClick for the PS3, XBoxOne and HID controllers
- Pulled Normal Output into it's own function
- Added BindMode in addition to NormalMode to handle when the adapter is binding to profiles