### PR TITLE
Extends support for the Mad Catz SFIV PS3 stick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.13.7] - 2020-10-04
+- Extended `Mad Catz Street Fighter IV Tournament Edition (PS3)` entry in `drivers.cpp` & `drivers.h` to support both editions (Round 1 & Round 2) of the controller.
+
 ## [0.13.6] - 2020-09-28
 - Added Support for the Qanba Obsidian in both PS3 and PS4 modes
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -39,7 +39,7 @@ This is a list of tested controllers. Please reach out to our Discord server if 
 - Real Arcade Pro - Soul Calibur VI Edition for Xbox One (requires USB HOST SHIELD 2.0 update)
 
 ### Mad Catz
-- Street Fighter IV - Arcade FightStick Tournament Edition PS3
+- Street Fighter IV - Arcade FightStick Tournament Edition PS3 (Round 1 & Round 2 versions)
 
 ### Microsoft
 - XboxOne Controller

--- a/RFUSB_to_DB15/drivers.cpp
+++ b/RFUSB_to_DB15/drivers.cpp
@@ -81,7 +81,13 @@ void setupController(uint16_t vid, uint16_t pid, HIDController *controller) {
       break;
 
     case VID_MADCATZ:
-      if(pid == PID_MADCATZ_SF_PS3) setupHoriRAP3(controller);
+      switch(pid) {
+        case PID_MADCATZ_SF_PS3_RND1:
+        case PID_MADCATZ_SF_PS3_RND2:
+        default:
+          setupHoriRAP3(controller);
+          break;
+      }
       break;
 
     case VID_NACON:

--- a/RFUSB_to_DB15/drivers.h
+++ b/RFUSB_to_DB15/drivers.h
@@ -46,7 +46,8 @@
 #define PID_HORI_RAP_PS3        0x0011 // HORI Real Arcade Pro.3 SA PS3コントローラ
 #define PID_HORI_RAP_V_PS3      0x008B // HORI RAP V HAYABUSA Controller(PS3)
 #define PID_HORI_RAP_V_PS4      0x008A // HORI RAP V HAYABUSA Controller(PS4)
-#define PID_MADCATZ_SF_PS3      0x8838 // Mad Catz Street Fighter IV Tournament Edition (PS3)
+#define PID_MADCATZ_SF_PS3_RND1 0x8818 // Mad Catz Street Fighter IV Tournament Edition Round 1 (PS3)
+#define PID_MADCATZ_SF_PS3_RND2 0x8838 // Mad Catz Street Fighter IV Tournament Edition Round 2 (PS3)
 #define PID_NACON_DAIJA_PS3     0x0904 // Nacon Daija (PS3)
 #define PID_NACON_DAIJA_PS4     0x0D09 // Nacon Daija (PS4)
 #define PID_QANBA_OBSIDIAN_PS3  0x2302 // Qanba Obsidian (PS3)


### PR DESCRIPTION
Extends support for the Mad Catz SFIV PS3 stick to include both versions (Round 1 and Round 2) of the controller.