### PR TITLE
Clear unbound buttons when exiting bind mode early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.14.4] - 2020-10-12
+### Changed
+- Exiting bind mode after binding at least one button will clear the binds for any buttons that weren't bound
+    - If you do not bind any keys, the old profile will be used instead
+
 ## [0.14.3] - 2020-10-12
 ### Added
 - Added Support for the Qanba Crystal in both PS3 and PS4 modes (PS3 mode requires USB HOST SHIELD 2.0 update).

--- a/RFUSB_to_DB15/HIDController.cpp
+++ b/RFUSB_to_DB15/HIDController.cpp
@@ -61,6 +61,8 @@ bool HIDController::GetButtonState(uint8_t button) {
       return (buttonState & MASK_RIGHT)  || (buttonState & MASK_UP_RIGHT) || (buttonState & MASK_DOWN_RIGHT);
     case BUTTON_LEFT :
       return (buttonState & MASK_LEFT)  || (buttonState & MASK_UP_LEFT) || (buttonState & MASK_DOWN_LEFT);
+    case BUTTON_NULL:
+      return false;
     default:
       // MASK_UP is the farthest right and BUTTON_UP is zero, so shift the
       // mask button times to get the correct mask for the button

--- a/RFUSB_to_DB15/USB2DB15.cpp
+++ b/RFUSB_to_DB15/USB2DB15.cpp
@@ -282,6 +282,11 @@ void USB2DB15::HandleProfileBindMode(uint8_t ddrc, uint8_t ddrd, Controller &con
     #ifndef RELEASE_MODE
     Serial.println("Normal Mode");
     #endif
+    if (cur_key > PROFILE_BUTTON_1) {
+      for(;cur_key < NUM_BUTTON_BINDINGS; cur_key++) {
+        profile.bindings[cur_key] = BUTTON_NULL;
+      }
+    }
     eeprom.SaveProfile(eeprom.LoadCurrentProfile(), profile);
     input_mode = NORMAL_MODE;
     LED::Off();

--- a/RFUSB_to_DB15/device_descriptor.h
+++ b/RFUSB_to_DB15/device_descriptor.h
@@ -45,5 +45,6 @@
 #define BUTTON_8          17  // L2
 #define BUTTON_9          18  // R3
 #define BUTTON_10         19  // L3
+#define BUTTON_NULL       255 // No button at all
 
 #endif //USB2DB15_DEVICE_DESCRIPTOR_H


### PR DESCRIPTION
The clears any unbound buttons when exiting bind mode early.  For example if you bind buttons 1-3 then let go of select it will clear buttons 4-6 to avoid double bindings and general undefined behavior