### PR TITLE
Add support for Astro City Mini Arcade Stick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.14.6] - 2020-12-19
+### Added
+- Added Support for the Astro City Mini Arcade Stick:
+	
 ## [0.14.5] - 2020-11-18
 ### Added
 - Added Support for the DaemonBite Retro Controllers To USB Adapters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [0.14.6] - 2020-12-19
 ### Added
-- Added Support for the Astro City Mini Arcade Stick:
+- Added Support for the Astro City Mini Arcade Stick.
 	
 ## [0.14.5] - 2020-11-18
 ### Added

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -81,7 +81,6 @@ This is a list of tested controllers. Please reach out to our Discord server if 
 - Sega Saturn Wireless Controller 2.4GHz (Via wireless USB receiver)
 	- Press START + UP to enable digital DPAD
 ### SEGA
-
 - Astro City Mini Arcade Stick
 
 ### Sony

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -80,6 +80,9 @@ This is a list of tested controllers. Please reach out to our Discord server if 
 ### Retrobit
 - Sega Saturn Wireless Controller 2.4GHz (Via wireless USB receiver)
 	- Press START + UP to enable digital DPAD
+### SEGA
+
+- Astro City Mini Arcade Stick
 
 ### Sony
 - Dual Shock 3

--- a/RFUSB_to_DB15/drivers.cpp
+++ b/RFUSB_to_DB15/drivers.cpp
@@ -134,6 +134,10 @@ void setupController(uint16_t vid, uint16_t pid, HIDController *controller) {
       }
       break;
 
+    case VID_SEGATOYS:
+      if (pid == PID_SEGA_ACS) setupSegaAstroCityMini(controller);
+      break;
+
     case VID_UPCB:
       if (pid == PID_UPCB) setupPS4(controller);
       break;
@@ -532,4 +536,37 @@ void setupPS4(HIDController *controller) {
   controller->ConfigButton(BUTTON_6, 6, 0x08);
   controller->ConfigButton(BUTTON_7, 6, 0x01);
   controller->ConfigButton(BUTTON_8, 6, 0x04);
+}
+
+/**************************
+ * Sega GamePads
+ **************************/
+
+/**
+ * Configures an 8BitDo SFC30 Wired Controller and Compatible devices
+ *
+ * 8BitDo SFC30 Button layout
+ * Byte 0x01   0x02   0x04   0x08   0x10   0x20   0x40   0x80
+ * 3:                   LEFT(0x00)/RIGHT(0xFF)
+ * 4:                   UP(0x00)/DOWN(0xFF)
+ * 5:   NA,    NA,    NA,    NA,    Btn 2, Btn 5, Btn 4, Btn 1
+ * 6:   Btn 3, Btn 6, NA,    NA,    COIN,  START, NA,    NA
+ *
+ * @param controller The HIDController that will be configured
+ */
+void setupSegaAstroCityMini(HIDController *controller) {
+  // DPad setup
+  controller->ConfigButton(BUTTON_LEFT, 3, 0xFF, 0);
+  controller->ConfigButton(BUTTON_RIGHT, 3, 0xFF, 0xFF);
+  controller->ConfigButton(BUTTON_UP, 4, 0xFF, 0);
+  controller->ConfigButton(BUTTON_DOWN, 4, 0xFF, 0xFF);
+  // Button setup
+  controller->ConfigButton(BUTTON_COIN, 6, 0x10);
+  controller->ConfigButton(BUTTON_START, 6, 0x20);
+  controller->ConfigButton(BUTTON_1, 5, 0x80);
+  controller->ConfigButton(BUTTON_2, 5, 0x10);
+  controller->ConfigButton(BUTTON_3, 6, 0x01);
+  controller->ConfigButton(BUTTON_4, 5, 0x40);
+  controller->ConfigButton(BUTTON_5, 5, 0x20);
+  controller->ConfigButton(BUTTON_6, 6, 0x02);
 }

--- a/RFUSB_to_DB15/drivers.h
+++ b/RFUSB_to_DB15/drivers.h
@@ -27,6 +27,7 @@
 #define VID_SONY                0x054c // Sony
 #define VID_UPCB                0x04D8 // Universal PCB Project
 #define VID_DAEMON              0x2341 // DaemonBite Retro Controllers (Standard Arduino Leonardo VID)
+#define VID_SEGATOYS            0x0CA3 // Sega Toys
 
 
 /****************
@@ -63,6 +64,7 @@
 #define PID_SONY_PS4_JP         0x09CC // PS4 Controller JP region
 #define PID_SONY_PS4_NA         0x05C4 // PS4 Controller NA region
 #define PID_UPCB                0x1529 // Universal PCB Project
+#define PID_SEGA_ACS            0x0028 // Arcade stick for Astro City Mini - ACS-1003
 
 /****************
  * D Pad Constants
@@ -110,5 +112,8 @@ void setupRetrobit_Saturn(HIDController *controller);
 
 // Sony
 void setupPS4(HIDController *controller);
+
+// Sega
+void setupSegaAstroCityMini(HIDController *controller);
 
 #endif //USB2DB15_DRIVERS_H


### PR DESCRIPTION
Not 100% sure about the naming conventions, if there's any preference let me know and I'll change them, or feel free to edit them.

The stick is technically made by sega toys not sega, that's where the name is from.