### PR TITLE
Add GamePad Generic and Bugfix on MadCatz TE2+ Start/Coin mode PS4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
-## [0.14.15] - 2022-05-15
+## [0.14.15] - 2022-05-26
+
 ### Changed
 - Fixed an issue with button mapping surrounding Mad Catz Street Fighter V Arcade FightStick TE2+ (PS4 Mode) controller.
+
+### Added
+- Added Support for Logitech F310
+	- Library updated: https://github.com/Raphfriend/USB_Host_Shield_2.0
+	- USB Host Shield 2.0 files updated:
+		- hidescriptorparser.cpp
+		- hidescriptorparser.h
+		- Usb.cpp
+		
 
 ### Added
 - Added Support for Feir Wired FR-225C Controller for PlayStation 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Fixed an issue with button mapping surrounding Mad Catz Street Fighter V Arcade FightStick TE2+ (PS4 Mode) controller.
 
 ### Added
-- Added Support for Generic Controller for PlayStation 4
+- Added Support for Feir Wired FR-225C Controller for PlayStation 4
 
 ## [0.14.14] - 2022-05-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.14.15] - 2022-05-15
+### Changed
+- Fixed an issue with button mapping surrounding Mad Catz Street Fighter V Arcade FightStick TE2+ (PS4 Mode) controller.
+
+### Added
+- Added Support for Generic Controller for PlayStation 4
+
 ## [0.14.14] - 2022-05-14
 ### Added
 - Added Support for PowerA FUSION Wired FightPad Gaming Controller for PlayStation 4

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -48,11 +48,9 @@ This is a list of tested controllers. Please reach out to our Discord server if 
 	- Save the file.
 
 ### Feir
-
 - Feir Wired FR-225C Controller for PlayStation 4
 
 ### FeralAI
-
 - Pico Fighting Board GP2040 (PS3/DirectInput Mode)
 
 ### Honcam
@@ -70,6 +68,9 @@ This is a list of tested controllers. Please reach out to our Discord server if 
 - Real Arcade Pro.3 Premium VLX (PS3 mode)
 - Real Arcade Pro V HAYABUSA (PS3 and PS4 modes)
 - Real Arcade Pro - Soul Calibur VI Edition for Xbox One (requires USB HOST SHIELD 2.0 update)
+
+### Logitech
+- F310 
 
 ### Mad Catz
 - Street Fighter IV - Arcade FightStick Tournament Edition PS3 (Round 1 & Round 2 versions)

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -47,6 +47,10 @@ This is a list of tested controllers. Please reach out to our Discord server if 
 			micro.build.usb_product="Arduino Micro"
 	- Save the file.
 
+### Feir
+
+- Feir Wired FR-225C Controller for PlayStation 4
+
 ### FeralAI
 
 - Pico Fighting Board GP2040 (PS3/DirectInput Mode)

--- a/RFUSB_to_DB15/drivers.cpp
+++ b/RFUSB_to_DB15/drivers.cpp
@@ -95,6 +95,10 @@ void setupController(uint16_t vid, uint16_t pid, HIDController *controller) {
           break;
       }
       break;
+		  
+	case VID_LOGITECH:
+      if (pid == PID_LOGITECH) setupLogitech(controller);
+      break;
 
     case VID_MADCATZ:
       switch (pid) {
@@ -148,6 +152,11 @@ void setupController(uint16_t vid, uint16_t pid, HIDController *controller) {
           break;
       }
       break;
+		  
+    case VID_SEGATOYS:
+      if (pid == PID_SEGA_ACS) setupSegaAstroCityMini(controller);
+      break;
+
 
     case VID_SONY:
       switch (pid) { 
@@ -166,10 +175,6 @@ void setupController(uint16_t vid, uint16_t pid, HIDController *controller) {
       }
       break;
 
-    case VID_SEGATOYS:
-      if (pid == PID_SEGA_ACS) setupSegaAstroCityMini(controller);
-      break;
-
     case VID_SHANWAN:
       if (pid == PID_NEOGEO_MINI_PAD) setupNeoGeoMini(controller);
       break;
@@ -179,6 +184,7 @@ void setupController(uint16_t vid, uint16_t pid, HIDController *controller) {
       break;
 
     default:
+		  
 #ifndef RELEASE_MODE
       Serial.println("Failed to find a driver for device. Using RAP PS3 as fallback");
 #endif
@@ -539,6 +545,42 @@ void setupHoriRAP3(HIDController *controller) {
   controller->ConfigButton(BUTTON_9, 1, 0x08);
   controller->ConfigButton(BUTTON_10, 1, 0x04);
 }
+
+
+/**************************
+ * Logitech GamePads
+ **************************/
+
+/**
+ * Configures a Logitech F310 and Compatible devices
+ *
+ * RAP Button layout
+ * Byte 0x01   0x02   0x04   0x08   0x10   0x20   0x40   0x80
+ * 0:   Btn 1, Btn 4, Btn 5, Btn 2, Btn 7, Btn 3, Btn 8, Btn 6
+ * 1:   COIN,  START, Btn 9, Btn10, NA,    NA,    NA,    NA
+ * 2:   DPAD,  DPAD,  DPAD,  DPAD,  NA,    NA,    NA,    NA
+ *
+ * @param controller The HIDController that will be configured
+ */
+void setupLogitech(HIDController *controller) {
+  // DPad setup
+  generateDPad(2, controller);
+  // Button setup
+  controller->ConfigButton(BUTTON_COIN, 1, 0x01);
+  controller->ConfigButton(BUTTON_START, 1, 0x02);
+  controller->ConfigButton(BUTTON_1, 0, 0x01);
+  controller->ConfigButton(BUTTON_2, 0, 0x08);
+  controller->ConfigButton(BUTTON_3, 0, 0x20);
+  controller->ConfigButton(BUTTON_4, 0, 0x02);
+  controller->ConfigButton(BUTTON_5, 0, 0x04);
+  controller->ConfigButton(BUTTON_6, 0, 0x80);
+  controller->ConfigButton(BUTTON_7, 0, 0x10);
+  controller->ConfigButton(BUTTON_8, 0, 0x40);
+  controller->ConfigButton(BUTTON_9, 1, 0x08);
+  controller->ConfigButton(BUTTON_10, 1, 0x04);
+}
+
+
 
 /**************************
  * Mad Catz GamePads

--- a/RFUSB_to_DB15/drivers.cpp
+++ b/RFUSB_to_DB15/drivers.cpp
@@ -554,7 +554,7 @@ void setupHoriRAP3(HIDController *controller) {
 /**
  * Configures a Logitech F310 and Compatible devices
  *
- * RAP Button layout
+ * Logitech F310 Button layout
  * Byte 0x01   0x02   0x04   0x08   0x10   0x20   0x40   0x80
  * 0:   Btn 1, Btn 4, Btn 5, Btn 2, Btn 7, Btn 3, Btn 8, Btn 6
  * 1:   COIN,  START, Btn 9, Btn10, NA,    NA,    NA,    NA
@@ -566,18 +566,17 @@ void setupLogitech(HIDController *controller) {
   // DPad setup
   generateDPad(2, controller);
   // Button setup
-  controller->ConfigButton(BUTTON_COIN, 1, 0x01);
-  controller->ConfigButton(BUTTON_START, 1, 0x02);
-  controller->ConfigButton(BUTTON_1, 0, 0x01);
-  controller->ConfigButton(BUTTON_2, 0, 0x08);
-  controller->ConfigButton(BUTTON_3, 0, 0x20);
-  controller->ConfigButton(BUTTON_4, 0, 0x02);
-  controller->ConfigButton(BUTTON_5, 0, 0x04);
-  controller->ConfigButton(BUTTON_6, 0, 0x80);
-  controller->ConfigButton(BUTTON_7, 0, 0x10);
-  controller->ConfigButton(BUTTON_8, 0, 0x40);
-  controller->ConfigButton(BUTTON_9, 1, 0x08);
-  controller->ConfigButton(BUTTON_10, 1, 0x04);
+  controller->ConfigButton(BUTTON_COIN, 1, 0x10);
+  controller->ConfigButton(BUTTON_START, 1, 0x20 );
+  controller->ConfigButton(BUTTON_1, 0, 0x28);
+  controller->ConfigButton(BUTTON_2, 0, 0x48);
+  controller->ConfigButton(BUTTON_3, 0, 0x18);
+  controller->ConfigButton(BUTTON_4, 0, 0x88);
+  controller->ConfigButton(BUTTON_5, 0, 0x08);
+  controller->ConfigButton(BUTTON_6, 1, 0x80);
+  controller->ConfigButton(BUTTON_7, 1, 0x04);
+  controller->ConfigButton(BUTTON_8, 1, 0x08);
+  
 }
 
 

--- a/RFUSB_to_DB15/drivers.cpp
+++ b/RFUSB_to_DB15/drivers.cpp
@@ -48,6 +48,7 @@ void setupController(uint16_t vid, uint16_t pid, HIDController *controller) {
 
     case VID_BROOK:
       if ((pid == PID_BROOK_UNIVERSAL) || (pid == PID_BROOK_FB)) setupPS4(controller);
+      if (pid == PID_PS4_Wired) setupPS4(controller);
       break;
 
     case VID_GENERIC:
@@ -558,8 +559,8 @@ void setupMadCatzTE2Plus(HIDController *controller) {
   /** DPad */
   generateDPad(5, controller);
   /** Buttons */
-  controller->ConfigButton(BUTTON_COIN,  6, 0x40);
-  controller->ConfigButton(BUTTON_START, 6, 0x80);
+  controller->ConfigButton(BUTTON_COIN,  6, 0x10);
+  controller->ConfigButton(BUTTON_START, 6, 0x20);
   controller->ConfigButton(BUTTON_1,     5, 0x10);
   controller->ConfigButton(BUTTON_2,     5, 0x80);
   controller->ConfigButton(BUTTON_3,     6, 0x02);

--- a/RFUSB_to_DB15/drivers.cpp
+++ b/RFUSB_to_DB15/drivers.cpp
@@ -48,7 +48,7 @@ void setupController(uint16_t vid, uint16_t pid, HIDController *controller) {
 
     case VID_BROOK:
       if ((pid == PID_BROOK_UNIVERSAL) || (pid == PID_BROOK_FB)) setupPS4(controller);
-      if (pid == PID_PS4_Wired) setupPS4(controller);
+      if (pid == PID_FEIR_PS4) setupPS4(controller);
       break;
 
     case VID_GENERIC:

--- a/RFUSB_to_DB15/drivers.cpp
+++ b/RFUSB_to_DB15/drivers.cpp
@@ -532,17 +532,17 @@ void setupHoriRAP3(HIDController *controller) {
   // DPad setup
   generateDPad(2, controller);
   // Button setup
-  controller->ConfigButton(BUTTON_COIN, 1, 0x01);
+  controller->ConfigButton(BUTTON_COIN,  1, 0x01);
   controller->ConfigButton(BUTTON_START, 1, 0x02);
-  controller->ConfigButton(BUTTON_1, 0, 0x01);
-  controller->ConfigButton(BUTTON_2, 0, 0x08);
-  controller->ConfigButton(BUTTON_3, 0, 0x20);
-  controller->ConfigButton(BUTTON_4, 0, 0x02);
-  controller->ConfigButton(BUTTON_5, 0, 0x04);
-  controller->ConfigButton(BUTTON_6, 0, 0x80);
-  controller->ConfigButton(BUTTON_7, 0, 0x10);
-  controller->ConfigButton(BUTTON_8, 0, 0x40);
-  controller->ConfigButton(BUTTON_9, 1, 0x08);
+  controller->ConfigButton(BUTTON_1,  0, 0x01);
+  controller->ConfigButton(BUTTON_2,  0, 0x08);
+  controller->ConfigButton(BUTTON_3,  0, 0x20);
+  controller->ConfigButton(BUTTON_4,  0, 0x02);
+  controller->ConfigButton(BUTTON_5,  0, 0x04);
+  controller->ConfigButton(BUTTON_6,  0, 0x80);
+  controller->ConfigButton(BUTTON_7,  0, 0x10);
+  controller->ConfigButton(BUTTON_8,  0, 0x40);
+  controller->ConfigButton(BUTTON_9,  1, 0x08);
   controller->ConfigButton(BUTTON_10, 1, 0x04);
 }
 
@@ -555,27 +555,27 @@ void setupHoriRAP3(HIDController *controller) {
  * Configures a Logitech F310 and Compatible devices
  *
  * Logitech F310 Button layout
- * Byte 0x01   0x02   0x04   0x08   0x10   0x20   0x40   0x80
- * 0:   Btn 1, Btn 4, Btn 5, Btn 2, Btn 7, Btn 3, Btn 8, Btn 6
- * 1:   COIN,  START, Btn 9, Btn10, NA,    NA,    NA,    NA
- * 2:   DPAD,  DPAD,  DPAD,  DPAD,  NA,    NA,    NA,    NA
+ * Byte   0x01   0x02   0x04   0x08   0x10   0x20   0x40   0x80
+ * 0-3:                           n/a
+ * 4:     DPAD ,  DPAD, DPAD,  DPAD, btn 3,  btn 1, btn 2, btn 4
+ * 5:     btn 5, btn 6, btn 7, btn 8, coin , start,   n/a,   n/a 
  *
  * @param controller The HIDController that will be configured
  */
 void setupLogitech(HIDController *controller) {
   // DPad setup
-  generateDPad(2, controller);
+  generateDPad(4, controller);
   // Button setup
-  controller->ConfigButton(BUTTON_COIN, 1, 0x10);
-  controller->ConfigButton(BUTTON_START, 1, 0x20 );
-  controller->ConfigButton(BUTTON_1, 0, 0x28);
-  controller->ConfigButton(BUTTON_2, 0, 0x48);
-  controller->ConfigButton(BUTTON_3, 0, 0x18);
-  controller->ConfigButton(BUTTON_4, 0, 0x88);
-  controller->ConfigButton(BUTTON_5, 0, 0x08);
-  controller->ConfigButton(BUTTON_6, 1, 0x80);
-  controller->ConfigButton(BUTTON_7, 1, 0x04);
-  controller->ConfigButton(BUTTON_8, 1, 0x08);
+  controller->ConfigButton(BUTTON_COIN,  5, 0x10);
+  controller->ConfigButton(BUTTON_START, 5, 0x20);
+  controller->ConfigButton(BUTTON_1, 4, 0x20);
+  controller->ConfigButton(BUTTON_2, 4, 0x40);
+  controller->ConfigButton(BUTTON_3, 4, 0x10);
+  controller->ConfigButton(BUTTON_4, 4, 0x80);
+  controller->ConfigButton(BUTTON_5, 5, 0x01);
+  controller->ConfigButton(BUTTON_6, 5, 0x02);
+  controller->ConfigButton(BUTTON_7, 5, 0x04);
+  controller->ConfigButton(BUTTON_8, 5, 0x08);
   
 }
 

--- a/RFUSB_to_DB15/drivers.h
+++ b/RFUSB_to_DB15/drivers.h
@@ -44,6 +44,8 @@
 #define PID_BROOK_FB            0x0ef7 // FIGHTING BOARD PS3/PS4 (PS4 Mode)
 #define PID_DAEMON_SNES         0x8036 // DaemonBite Retro Controllers SNES (Standard Arduino Leonardo PID)
 #define PID_DAEMON_SATURN       0x8030 // DaemonBite Retro Controllers Saturn (Modded PID to suit the USB2DB15, check COMPATIBILITY.md)
+#define PID_FEIR_PS4            0x1E1B // Feir Wired FR-225C Controller for PlayStation 4
+#define PID_FUSION_PS4          0x792A // PowerA FUSION Wired FightPad Gaming Controller (PS4)
 #define PID_GENERIC_SNES        0x0011 // Generic SNES pad
 #define PID_GENERIC_ZERO_DELAY  0x0006 // Generic Zero Delay PCB 01
 #define PID_HONCAM              0xA713 // Honcam HC-J2003
@@ -66,7 +68,6 @@
 #define PID_NACON_DAIJA_PS3     0x0904 // Nacon Daija (PS3)
 #define PID_NACON_DAIJA_PS4     0x0D09 // Nacon Daija (PS4)
 #define PID_NEOGEO_MINI_PAD     0x0575 // Neo Geo Mini Pad
-#define PID_FUSION_PS4          0x792A // PowerA FUSION Wired FightPad Gaming Controller (PS4)
 #define PID_QANBA_CRYSTAL_PS4   0x2200 // Qanba Crystal (PS4)
 #define PID_QANBA_OBSIDIAN_PS3  0x2302 // Qanba Obsidian (PS3)
 #define PID_QANBA_OBSIDIAN_PS4  0x2300 // Qanba Obsidian (PS4)
@@ -74,14 +75,15 @@
 #define PID_RAZER_PANTHERA_EVO  0x1008 // Razer Panthera EVO (PS4)
 #define PID_RAZER_RAIJU_ULT     0x1004 // Razer Raiju Ultimate (PS4)
 #define PID_RETROBIT_SATURN     0x00C1 // Retrobit Sega Saturn Wireless 2.4G
+#define PID_SEGA_ACS            0x0028 // Arcade stick for Astro City Mini - ACS-1003
 #define PID_SONY_PS4_ADAPTER    0x0BA0 // PS4 Wireless Adapter
 #define PID_SONY_PS4_JP         0x09CC // PS4 Controller JP region
 #define PID_SONY_PS4_NA         0x05C4 // PS4 Controller NA region
 #define PID_SONY_PS5_NA         0x0CE6 // PS5 Controller NA region
 #define PID_SONY_PSC	          0x0CDA // Playstation Classic Controller
 #define PID_UPCB                0x1529 // Universal PCB Project
-#define PID_SEGA_ACS            0x0028 // Arcade stick for Astro City Mini - ACS-1003
-#define PID_FEIR_PS4            0x1E1B // Feir Wired FR-225C Controller for PlayStation 4
+
+
 
 
 /****************

--- a/RFUSB_to_DB15/drivers.h
+++ b/RFUSB_to_DB15/drivers.h
@@ -29,7 +29,6 @@
 #define VID_SONY                0x054c // Sony
 #define VID_UPCB                0x04D8 // Universal PCB Project
 #define VID_DAEMON              0x2341 // DaemonBite Retro Controllers (Standard Arduino Leonardo VID)
-#define PID_PS4_Wired           0x1E1B // Generic Gamepad PS4 Wired
 
 
 /****************
@@ -80,6 +79,7 @@
 #define PID_SONY_PSC	          0x0CDA // Playstation Classic Controller
 #define PID_UPCB                0x1529 // Universal PCB Project
 #define PID_SEGA_ACS            0x0028 // Arcade stick for Astro City Mini - ACS-1003
+#define PID_PS4_Wired           0x1E1B // Generic Gamepad PS4 Wired
 
 
 /****************

--- a/RFUSB_to_DB15/drivers.h
+++ b/RFUSB_to_DB15/drivers.h
@@ -128,6 +128,10 @@ void setupHoncam(HIDController *controller);
 void setupHoriFightingCmdr(HIDController *controller);
 void setupHoriRAP3(HIDController *controller);
 
+// Logitech
+
+void setupLogitech(HIDController *controller);
+
 // MadCatz 
 void setupMadCatzTE2Plus(HIDController *controller);
 

--- a/RFUSB_to_DB15/drivers.h
+++ b/RFUSB_to_DB15/drivers.h
@@ -79,7 +79,7 @@
 #define PID_SONY_PSC	          0x0CDA // Playstation Classic Controller
 #define PID_UPCB                0x1529 // Universal PCB Project
 #define PID_SEGA_ACS            0x0028 // Arcade stick for Astro City Mini - ACS-1003
-#define PID_PS4_Wired           0x1E1B // Generic Gamepad PS4 Wired
+#define PID_FEIR_PS4            0x1E1B // Feir Wired FR-225C Controller for PlayStation 4
 
 
 /****************

--- a/RFUSB_to_DB15/drivers.h
+++ b/RFUSB_to_DB15/drivers.h
@@ -29,6 +29,7 @@
 #define VID_SONY                0x054c // Sony
 #define VID_UPCB                0x04D8 // Universal PCB Project
 #define VID_DAEMON              0x2341 // DaemonBite Retro Controllers (Standard Arduino Leonardo VID)
+#define PID_PS4_Wired           0x1E1B // Generic Gamepad PS4 Wired
 
 
 /****************

--- a/RFUSB_to_DB15/drivers.h
+++ b/RFUSB_to_DB15/drivers.h
@@ -17,9 +17,11 @@
 #define VID_8BITDO              0x2DC8 // 8BitDo Bluetooth (D-INPUT MODE)
 #define VID_BROOK               0x0C12 // Brook
 #define VID_BUFFALO             0x0583 // Buffalo
+#define VID_DAEMON              0x2341 // DaemonBite Retro Controllers (Standard Arduino Leonardo VID)
 #define VID_GENERIC             0x0079 // Generic
 #define VID_HONCAM              0x20D6 // Honcam
 #define VID_HORI                0x0F0D // HORI (Also used by Retrobit 2.4GHz)
+#define VID_LOGITECH            0x046D // Logitech
 #define VID_MADCATZ             0x0738 // Mad Catz
 #define VID_NACON               0x146B // Nacon
 #define VID_QANBA               0x2C22 // Qanba
@@ -28,7 +30,6 @@
 #define VID_SHANWAN             0x2563 // Shenzhen ShanWan Technology Co., Ltd.
 #define VID_SONY                0x054c // Sony
 #define VID_UPCB                0x04D8 // Universal PCB Project
-#define VID_DAEMON              0x2341 // DaemonBite Retro Controllers (Standard Arduino Leonardo VID)
 
 
 /****************
@@ -41,6 +42,8 @@
 #define PID_BUFFALO_CLASSIC     0x2060 // iBUFFALO SNES CLASSIC USB GAMEPAD
 #define PID_BROOK_UNIVERSAL     0x0C30 // Brook Universal Fighting PCB
 #define PID_BROOK_FB            0x0ef7 // FIGHTING BOARD PS3/PS4 (PS4 Mode)
+#define PID_DAEMON_SNES         0x8036 // DaemonBite Retro Controllers SNES (Standard Arduino Leonardo PID)
+#define PID_DAEMON_SATURN       0x8030 // DaemonBite Retro Controllers Saturn (Modded PID to suit the USB2DB15, check COMPATIBILITY.md)
 #define PID_GENERIC_SNES        0x0011 // Generic SNES pad
 #define PID_GENERIC_ZERO_DELAY  0x0006 // Generic Zero Delay PCB 01
 #define PID_HONCAM              0xA713 // Honcam HC-J2003
@@ -51,10 +54,9 @@
 #define PID_HORI_LITE           0x00EE // HORI ワイヤードコントローラライト for PS4-102
 #define PID_HORI_RAP_PREMIUM    0x0026 // HORI Real Arcade リアルアーケードPro.3 Premium VLX
 #define PID_HORI_RAP_PS3        0x0011 // HORI Real Arcade Pro.3 SA PS3コントローラ
-#define PID_DAEMON_SNES         0x8036 // DaemonBite Retro Controllers SNES (Standard Arduino Leonardo PID)
-#define PID_DAEMON_SATURN       0x8030 // DaemonBite Retro Controllers Saturn (Modded PID to suit the USB2DB15, check COMPATIBILITY.md)
 #define PID_HORI_RAP_V_PS3      0x008B // HORI RAP V HAYABUSA Controller(PS3)
 #define PID_HORI_RAP_V_PS4      0x008A // HORI RAP V HAYABUSA Controller(PS4)
+#define PID_LOGITECH            0xC216 // Logitech F310
 #define PID_MADCATZ_FSA_PS4     0x8180 // Mad Catz Fight Stick Alpha (PS4)
 #define PID_MADCATZ_FSA_PS3     0x3180 // Mad Catz Fight Stick Alpha (PS3)
 #define PID_MADCATZ_SF_PS3_RND1 0x8818 // Mad Catz Street Fighter IV Tournament Edition Round 1 (PS3)


### PR DESCRIPTION
I try add a generic gamepad ps4 wired and fix madcatz TE2+ on PS4 mode, because Start and Coin not work for me.
