### PR TITLE
add Control Pad for Astro City Mini - ACS-1002

### DIFF
--- a/RFUSB_to_DB15/drivers.cpp
+++ b/RFUSB_to_DB15/drivers.cpp
@@ -336,9 +336,9 @@ void setupBuffaloClassic(HIDController *controller) {
  * Configures a Fire NEOGEOX Arcade Stick and Compatible devices
  *
  * NEOGEOX Arcade Stick Button layout
- * Byte 0x01   0x02   0x04   0x08
- * 0:   Btn 1, Btn 4, Btn 5, Btn 2,
- * 1:   COIN,  START, Btn 9, Btn10, NA,    NA,    NA,    NA
+ * Byte 0x01   0x02   0x04   0x08   0x10   0x20   0x40   0x80
+ * 0:   Btn 4, Btn 5, Btn 2, Btn 1, NA,    NA,    NA,    NA
+ * 1:   COIN,  START, NA,    NA,    NA,    NA,    NA,    NA
  * 2:   DPAD,  DPAD,  DPAD,  DPAD,  NA,    NA,    NA,    NA
  *
  * @param controller The HIDController that will be configured

--- a/RFUSB_to_DB15/drivers.cpp
+++ b/RFUSB_to_DB15/drivers.cpp
@@ -154,7 +154,12 @@ void setupController(uint16_t vid, uint16_t pid, HIDController *controller) {
       break;
 		  
     case VID_SEGATOYS:
-      if (pid == PID_SEGA_ACS) setupSegaAstroCityMini(controller);
+      switch (pid) {
+        case PID_SEGA_ACS_1002:
+        case PID_SEGA_ACS_1003:
+          setupSegaAstroCityMini(controller);
+          break;
+      }
       break;
 
 

--- a/RFUSB_to_DB15/drivers.cpp
+++ b/RFUSB_to_DB15/drivers.cpp
@@ -407,19 +407,19 @@ void setupGenericZeroDelay(HIDController *controller) {
  */
 void setupDaemonSNES(HIDController *controller) {
   // DPad setup
-  controller->ConfigButton(BUTTON_LEFT, 3, 0xFF, 0xFF);
-  controller->ConfigButton(BUTTON_RIGHT, 3, 0xFF, 0x01);
-  controller->ConfigButton(BUTTON_UP, 4, 0xFF, 0xFF);
-  controller->ConfigButton(BUTTON_DOWN, 4, 0xFF, 0x01);
+  controller->ConfigButton(BUTTON_LEFT, 1, 0xFF, 0xFF);
+  controller->ConfigButton(BUTTON_RIGHT, 1, 0xFF, 0x01);
+  controller->ConfigButton(BUTTON_UP, 2, 0xFF, 0xFF);
+  controller->ConfigButton(BUTTON_DOWN, 2, 0xFF, 0x01);
   // Button setup
   controller->ConfigButton(BUTTON_COIN, 0, 0x40);
   controller->ConfigButton(BUTTON_START, 0, 0x80);
   controller->ConfigButton(BUTTON_1, 0, 0x04);
   controller->ConfigButton(BUTTON_2, 0, 0x08);
-  controller->ConfigButton(BUTTON_3, 0, 0x20);
+  controller->ConfigButton(BUTTON_3, 0, 0x10);
   controller->ConfigButton(BUTTON_4, 0, 0x01);
   controller->ConfigButton(BUTTON_5, 0, 0x02);
-  controller->ConfigButton(BUTTON_6, 0, 0x10);
+  controller->ConfigButton(BUTTON_6, 0, 0x20);
 
 }
 

--- a/RFUSB_to_DB15/drivers.cpp
+++ b/RFUSB_to_DB15/drivers.cpp
@@ -50,7 +50,11 @@ void setupController(uint16_t vid, uint16_t pid, HIDController *controller) {
       if ((pid == PID_BROOK_UNIVERSAL) || (pid == PID_BROOK_FB)) setupPS4(controller);
       if (pid == PID_FEIR_PS4) setupPS4(controller);
       break;
-
+		  
+    case VID_FIRE:
+      if (pid == PID_FIRE_NEOGEOX_AS) setupFireNEOGEOXAS(controller);
+      break;
+		  
     case VID_GENERIC:
       if (pid == PID_GENERIC_SNES) setupGenericSNES(controller);
       if (pid == PID_GENERIC_ZERO_DELAY) setupGenericZeroDelay(controller);
@@ -322,6 +326,33 @@ void setupBuffaloClassic(HIDController *controller) {
   controller->ConfigButton(BUTTON_4, 2, 0x02);
   controller->ConfigButton(BUTTON_5, 2, 0x01);
   controller->ConfigButton(BUTTON_6, 2, 0x10);
+}
+
+/**************************
+ * Fire GamePads
+ **************************/
+
+/**
+ * Configures a Fire NEOGEOX Arcade Stick and Compatible devices
+ *
+ * NEOGEOX Arcade Stick Button layout
+ * Byte 0x01   0x02   0x04   0x08
+ * 0:   Btn 1, Btn 4, Btn 5, Btn 2,
+ * 1:   COIN,  START, Btn 9, Btn10, NA,    NA,    NA,    NA
+ * 2:   DPAD,  DPAD,  DPAD,  DPAD,  NA,    NA,    NA,    NA
+ *
+ * @param controller The HIDController that will be configured
+ */
+void setupFireNEOGEOXAS(HIDController *controller) {
+  // DPad setup
+  generateDPad(2, controller);
+  // Button setup
+  controller->ConfigButton(BUTTON_COIN,  1, 0x01);
+  controller->ConfigButton(BUTTON_START, 1, 0x02);
+  controller->ConfigButton(BUTTON_1,  0, 0x08);
+  controller->ConfigButton(BUTTON_2,  0, 0x04);
+  controller->ConfigButton(BUTTON_4,  0, 0x01);
+  controller->ConfigButton(BUTTON_5,  0, 0x02);
 }
 
 /**************************

--- a/RFUSB_to_DB15/drivers.h
+++ b/RFUSB_to_DB15/drivers.h
@@ -18,6 +18,7 @@
 #define VID_BROOK               0x0C12 // Brook
 #define VID_BUFFALO             0x0583 // Buffalo
 #define VID_DAEMON              0x2341 // DaemonBite Retro Controllers (Standard Arduino Leonardo VID)
+#define VID_FIRE                0x1292 // Fire International Ltd.
 #define VID_GENERIC             0x0079 // Generic
 #define VID_HONCAM              0x20D6 // Honcam
 #define VID_HORI                0x0F0D // HORI (Also used by Retrobit 2.4GHz)
@@ -45,6 +46,7 @@
 #define PID_DAEMON_SNES         0x8036 // DaemonBite Retro Controllers SNES (Standard Arduino Leonardo PID)
 #define PID_DAEMON_SATURN       0x8030 // DaemonBite Retro Controllers Saturn (Modded PID to suit the USB2DB15, check COMPATIBILITY.md)
 #define PID_FEIR_PS4            0x1E1B // Feir Wired FR-225C Controller for PlayStation 4
+#define PID_FIRE_NEOGEOX_AS     0x4e47 // Fire NEOGEOX Arcade Stick
 #define PID_FUSION_PS4          0x792A // PowerA FUSION Wired FightPad Gaming Controller (PS4)
 #define PID_GENERIC_SNES        0x0011 // Generic SNES pad
 #define PID_GENERIC_ZERO_DELAY  0x0006 // Generic Zero Delay PCB 01
@@ -121,6 +123,8 @@ void setupDaemonSNES(HIDController *controller);
 // Daemon Saturn
 void setupDaemonSaturn(HIDController *controller);
 
+// Fire
+void setupFireNEOGEOXAS(HIDController *controller);
 
 // Honcam Controllers
 void setupHoncam(HIDController *controller);

--- a/RFUSB_to_DB15/drivers.h
+++ b/RFUSB_to_DB15/drivers.h
@@ -75,7 +75,8 @@
 #define PID_RAZER_PANTHERA_EVO  0x1008 // Razer Panthera EVO (PS4)
 #define PID_RAZER_RAIJU_ULT     0x1004 // Razer Raiju Ultimate (PS4)
 #define PID_RETROBIT_SATURN     0x00C1 // Retrobit Sega Saturn Wireless 2.4G
-#define PID_SEGA_ACS            0x0028 // Arcade stick for Astro City Mini - ACS-1003
+#define PID_SEGA_ACS_1002       0x0027 // Control Pad for Astro City Mini - ACS-1002
+#define PID_SEGA_ACS_1003       0x0028 // Arcade stick for Astro City Mini - ACS-1003
 #define PID_SONY_PS4_ADAPTER    0x0BA0 // PS4 Wireless Adapter
 #define PID_SONY_PS4_JP         0x09CC // PS4 Controller JP region
 #define PID_SONY_PS4_NA         0x05C4 // PS4 Controller NA region


### PR DESCRIPTION
add Control Pad for Astro City Mini - ACS-1002 and differentiate device of SEGATOYS (ACS-1002, ACS-1003)