### PR TITLE
Added support for Qanba Drone (PID 2000, VID 2C222)

### DIFF
--- a/RFUSB_to_DB15/drivers.cpp
+++ b/RFUSB_to_DB15/drivers.cpp
@@ -132,6 +132,7 @@ void setupController(uint16_t vid, uint16_t pid, HIDController *controller) {
     case VID_QANBA:
       switch (pid) {
         case PID_QANBA_CRYSTAL_PS4:
+        case PID_QANBA_DRONE_PS4:
         case PID_QANBA_OBSIDIAN_PS4:
           setupPS4(controller);
           break;

--- a/RFUSB_to_DB15/drivers.h
+++ b/RFUSB_to_DB15/drivers.h
@@ -69,6 +69,7 @@
 #define PID_NACON_DAIJA_PS4     0x0D09 // Nacon Daija (PS4)
 #define PID_NEOGEO_MINI_PAD     0x0575 // Neo Geo Mini Pad
 #define PID_QANBA_CRYSTAL_PS4   0x2200 // Qanba Crystal (PS4)
+#define PID_QANBA_DRONE_PS4     0x2000 // Qanba Drone (PS4)
 #define PID_QANBA_OBSIDIAN_PS3  0x2302 // Qanba Obsidian (PS3)
 #define PID_QANBA_OBSIDIAN_PS4  0x2300 // Qanba Obsidian (PS4)
 #define PID_RAZER_PANTHERA      0x0401 // Razer Panthera (PS4)


### PR DESCRIPTION
Added support for Qanba Drone (in PS4 mode). Verified with three Drone sticks on two USB2DB15 V1.1 adapters with a Minigun supergun. Tested on CPS2 with 6-button game. Share adds a coin; Options is start; Square, Triangle, R1 are LP, MP, HP; X, Circle, R2 are LK, MK, HK. Works in the default "Mode," where the Drone's LED is off - the Mode" button switches between D-Pad, left stick, and right stick. All other buttons appear to have no function on CPS2.