### PR TITLE
Adding support for the Victrix Pro FS With Touchpad for PS4 controller

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -125,3 +125,6 @@ This is a list of tested controllers. Please reach out to our Discord server if 
 
 ### Universal PCB Project
 - Universal PCB Firmware 29
+
+### Victrix
+- Victrix Pro FS with Touch Pad for PS4

--- a/RFUSB_to_DB15/drivers.cpp
+++ b/RFUSB_to_DB15/drivers.cpp
@@ -195,6 +195,9 @@ void setupController(uint16_t vid, uint16_t pid, HIDController *controller) {
       if (pid == PID_UPCB) setupPS4(controller);
       break;
 
+    case VID_PDP:
+      if (pid == PID_PDP_PRO_FS_PS4) setupPS4(controller);
+      break;
     default:
 		  
 #ifndef RELEASE_MODE

--- a/RFUSB_to_DB15/drivers.h
+++ b/RFUSB_to_DB15/drivers.h
@@ -32,6 +32,7 @@
 #define VID_SHANWAN             0x2563 // Shenzhen ShanWan Technology Co., Ltd.
 #define VID_SONY                0x054c // Sony
 #define VID_UPCB                0x04D8 // Universal PCB Project
+#define VID_PDP                 0x0E6F // Performance Designed Products, LLC (Victrix)
 
 
 /****************
@@ -88,7 +89,7 @@
 #define PID_SONY_PS5_NA         0x0CE6 // PS5 Controller NA region
 #define PID_SONY_PSC	        0x0CDA // Playstation Classic Controller
 #define PID_UPCB                0x1529 // Universal PCB Project
-
+#define PID_PDP_PRO_FS_PS4      0x0207 // Victrix Pro FS with Touch Pad for PS4
 
 
 


### PR DESCRIPTION
# Changes
- Added PDP vendor ID (Performance Designed Products, LLC - aka Victrix)
- Added Victrix Pro FS with Touch Pad for PS4 product ID
- Victrix Pro FS with Touch Pad for PS4 configured as a standard PS4 controller, confirmed works well
- Added Victrix PRO FS with Touch Pad for PS4 to compatibility list